### PR TITLE
v0.4.0 — Runtime schema validation, DENIED outcomes, schema version negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-30
+
+### Added
+
+- **Runtime event validation** — new `validate_events` config option enables JSON-schema
+  validation of every emitted event before it reaches the sink.  Configurable via
+  `validation_failure_mode` (`"drop"`, `"log_and_emit"`, `"raise"`).
+- **`AuditValidationError`** — new public exception raised when `validation_failure_mode`
+  is `"raise"` and an event fails schema validation.  Carries `event_id` and `errors`
+  attributes.
+- **`validate_event()` function** — public utility to validate an event dict against a
+  specific schema version.  Useful for testing and offline validation.
+- **Validation timing** — `AuditStats` now tracks `validation_time_ms_total` (cumulative
+  milliseconds spent on validation), exposed via `stats.snapshot()`.
+- **Denial reason callback** — new `AuditConfig.get_denial_reason` callback
+  `(Request, exc_info) -> str | None` enables setting rich `error_type` values on DENIED
+  outcomes (e.g. `"RoleDenied"`, `"ConsentRequired"`, `"CrossOrgAccessDenied"`).
+- **Configurable denied status codes** — new `AuditConfig.denied_status_codes` field
+  (default `frozenset({401, 403})`) controls which HTTP status codes produce DENIED
+  outcomes.
+- **Schema negotiation** — new `AuditConfig.target_schema_version` field (`"1.0"` or
+  `"1.1"`, default `"1.1"`) controls which schema version appears in emitted events.
+  When set to `"1.0"`, DENIED outcomes are automatically downgraded to FAILURE.
+- **Vendored v1.0 schema** — `schema/versions/1.0/audit_event.schema.json` now bundled
+  alongside v1.1 for offline validation of both versions.
+- **Version-aware schema loading** — `get_schema_path(version)` and
+  `load_schema(version)` accept an explicit version parameter.
+- **Example events** — four example JSON files in `examples/`: service-to-service,
+  access-denied-role, access-denied-consent, cross-org-access-denied.
+- **Migration guide** — `docs/migrating-1.0-to-1.1.md` documents the schema differences
+  and gradual migration path using `target_schema_version`.
+
+### Changed
+
+- **`jsonschema` is now a required dependency** — moved from optional extras to core
+  `dependencies` (`jsonschema>=4.20,<5`).  The `[jsonschema]` extra is kept for
+  backward compatibility but is now a no-op.
+- `_build_outcome` now accepts a `request` parameter to support the denial reason
+  callback.
+- `_DENIED_STATUS_CODES` module-level constant removed; replaced by
+  `AuditConfig.denied_status_codes` instance field.
+- `_build_event` now uses `self.config.target_schema_version` instead of the
+  `SCHEMA_VERSION` constant.
+
+### Compatibility
+
+- Python 3.11+ unchanged.
+- No breaking changes to the default emitted event shape — existing consumers see
+  identical events unless new config options are opted into.
+- `AuditConfig` gains five new optional fields (all have safe defaults).
+- The `[jsonschema]` extra is now redundant but still installable.
+
 ## [0.3.0] - 2026-03-28
 
 ### Added
@@ -219,7 +271,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apache 2.0 license
 - Vendored bh-audit-schema v1.0 JSON schema
 
-[Unreleased]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -15,9 +15,17 @@ The goal of this library is to make consistent, structured audit trails easy to 
 
 This project is an implementation layer that turns the bh-audit-schema standard into working FastAPI middleware.
 
-**Current version: v0.3.0** — Pure ASGI middleware, non-blocking async emission, typed event blocks, schema v1.1 with HIPAA/SOC compliance rules.
+**Current version: v0.4.0** — Runtime validation, DENIED outcome with denial callbacks, schema negotiation (v1.0/v1.1), vendored dual-schema support.
 
-### v0.3 (current)
+### v0.4 (current)
+- **Runtime event validation** — optional `validate_events=True` checks every event against the vendored JSON schema before emission, with configurable failure modes (`drop`, `log_and_emit`, `raise`)
+- **DENIED outcome with denial callback** — `get_denial_reason` callback provides rich denial categories (e.g. `RoleDenied`, `ConsentRequired`, `CrossOrgAccessDenied`) for compliance queries
+- **Configurable denied status codes** — `denied_status_codes` config (default `{401, 403}`)
+- **Schema negotiation** — `target_schema_version` config (`"1.0"` or `"1.1"`) controls which schema version is emitted, enabling gradual migration
+- **Vendored dual schemas** — both v1.0 and v1.1 schemas bundled for offline validation
+- **Validation timing** — `validation_time_ms_total` counter for monitoring validation overhead
+
+### v0.3
 - **Pure ASGI middleware** — no BaseHTTPMiddleware, supports streaming responses
 - **Non-blocking async emission** — bounded `asyncio.Queue` (default 10k events) with background drain task
 - **Typed event blocks** — `TypedDict` definitions for all event sub-blocks (`AuditEvent`, `ActorBlock`, etc.)
@@ -34,7 +42,7 @@ This project is an implementation layer that turns the bh-audit-schema standard 
   - `SQLAlchemySink` — relational database storage (Postgres, SQLite, etc., via SQLAlchemy Core)
 - Redaction utilities for error message sanitization
 
-The bh-audit-schema v1.1 JSON schema is vendored into this package to enable offline validation.
+The bh-audit-schema v1.0 and v1.1 JSON schemas are vendored into this package to enable offline validation.
 
 ## Quickstart
 
@@ -208,6 +216,56 @@ sink = SQLAlchemySink("postgresql://user:pass@localhost/mydb")
 
 See [docs/indexing.md](docs/indexing.md) for recommended database indexes and query examples.
 
+## Runtime Event Validation
+
+v0.4 adds optional runtime validation against the vendored JSON schema:
+
+```python
+config = AuditConfig(
+    service_name="my-api",
+    validate_events=True,                       # enable validation
+    validation_failure_mode="log_and_emit",      # "drop" (default), "log_and_emit", or "raise"
+)
+```
+
+- `"drop"` — increment counters and silently discard invalid events
+- `"log_and_emit"` — log validation errors but still emit the event
+- `"raise"` — raise `AuditValidationError` (use in dev/test)
+
+Validation timing is tracked in `stats.snapshot()["validation_time_ms_total"]`.
+
+## DENIED Outcome and Denial Callbacks
+
+HTTP 401/403 produce `outcome.status: "DENIED"` (v1.1) with an `error_type`.
+Provide a callback for richer denial categories:
+
+```python
+def denial_reason(request, exc_info):
+    if exc_info and "consent" in exc_info[0].lower():
+        return "ConsentRequired"
+    return None  # fall back to default
+
+config = AuditConfig(
+    service_name="my-api",
+    get_denial_reason=denial_reason,
+    denied_status_codes=frozenset({401, 403, 451}),  # customize
+)
+```
+
+## Schema Negotiation
+
+Control which schema version emitted events conform to:
+
+```python
+config = AuditConfig(
+    service_name="my-api",
+    target_schema_version="1.0",  # or "1.1" (default)
+)
+```
+
+With `"1.0"`, DENIED outcomes are downgraded to FAILURE for backward compatibility.
+See [docs/migrating-1.0-to-1.1.md](docs/migrating-1.0-to-1.1.md) for a full migration guide.
+
 ## Configuration
 
 `AuditConfig` supports (frozen after creation):
@@ -220,6 +278,7 @@ See [docs/indexing.md](docs/indexing.md) for recommended database indexes and qu
 | `default_actor_id` | `"unknown"` | Default actor when no auth context |
 | `default_actor_type` | `"service"` | Default actor type (`"human"` or `"service"`) |
 | `get_actor` | `None` | Callback `(Request) -> dict` for custom actor extraction |
+| `get_action` | `None` | Callback `(Request) -> dict` for custom action extraction |
 | `get_resource` | `None` | Callback `(Request, int) -> dict` for custom resource extraction |
 | `get_metadata` | `None` | Callback `(Request, int) -> dict` for custom metadata |
 | `metadata_allowlist` | `frozenset()` | Allowed metadata keys (empty = no metadata) |
@@ -231,6 +290,11 @@ See [docs/indexing.md](docs/indexing.md) for recommended database indexes and qu
 | `emit_mode` | `"queue"` | `"sync"` or `"queue"` (non-blocking) |
 | `queue_size` | `10_000` | Maximum pending events in queue |
 | `queue_drain_timeout` | `5.0` | Seconds to wait for queue drain on shutdown |
+| `validate_events` | `False` | Enable runtime JSON-schema validation |
+| `validation_failure_mode` | `"drop"` | `"drop"`, `"log_and_emit"`, or `"raise"` |
+| `get_denial_reason` | `None` | Callback `(Request, exc_info) -> str\|None` for denial categorization |
+| `denied_status_codes` | `frozenset({401, 403})` | Status codes that produce DENIED outcome |
+| `target_schema_version` | `"1.1"` | Schema version for emitted events (`"1.0"` or `"1.1"`) |
 
 ## PHI-safe defaults
 
@@ -255,8 +319,9 @@ pip install bh-fastapi-audit
 
 ```bash
 pip install bh-fastapi-audit[sqlalchemy]    # Database sink
-pip install bh-fastapi-audit[jsonschema]    # Full JSON schema validation
 ```
+
+> **Note:** `jsonschema` is a required dependency as of v0.4.0 (runtime validation support).
 
 ### Development installation
 

--- a/docs/migrating-1.0-to-1.1.md
+++ b/docs/migrating-1.0-to-1.1.md
@@ -1,0 +1,136 @@
+# Migrating from Schema v1.0 to v1.1
+
+This guide covers the changes between bh-audit-schema v1.0 and v1.1 as they
+affect consumers of `bh-fastapi-audit`.
+
+## What Changed in Schema v1.1
+
+| Area | v1.0 | v1.1 |
+|------|------|------|
+| `outcome.status` | `SUCCESS`, `FAILURE` | `SUCCESS`, `FAILURE`, **`DENIED`** |
+| `outcome` on FAILURE | `error_type` optional | `error_type` **and** `error_message` required |
+| `outcome` on DENIED | n/a | `error_type` required, `error_message` optional |
+| `actor.owner_org_id` | not present | new optional field for cross-org access detection |
+| String fields | no bounds | `minLength` / `maxLength` constraints on all strings |
+| `metadata` values | any type | scalar-only (`string`, `integer`, `number`, `boolean`, `null`) |
+| `event_id` | `minLength: 16` | `format: uuid`, fixed `minLength: 36`, `maxLength: 36` |
+| `correlation` | any subset allowed | `minProperties: 1` when present |
+| `http.method` | free string | `enum` restricted to standard HTTP methods |
+| `http.status_code` | integer | `minimum: 100`, `maximum: 599` |
+| `http.client_ip` | free string | `format: ipv4` or `format: ipv6` |
+
+## Gradual Migration with `target_schema_version`
+
+`bh-fastapi-audit` v0.4.0 vendors **both** schema versions and supports a
+gradual migration via the `target_schema_version` config field.
+
+### Step 1: Start with v1.0 compatibility
+
+If your downstream consumers are not yet ready for v1.1 events (e.g. a SIEM
+pipeline that rejects unknown `outcome.status` values), pin to v1.0:
+
+```python
+config = AuditConfig(
+    service_name="my-api",
+    target_schema_version="1.0",
+)
+```
+
+With `target_schema_version="1.0"`:
+
+- `schema_version` in emitted events is `"1.0"`
+- HTTP 401/403 produce `FAILURE` (not `DENIED`) with `error_type` and `error_message`
+- Events pass v1.0 schema validation
+
+### Step 2: Switch to v1.1
+
+When your downstream pipeline supports DENIED:
+
+```python
+config = AuditConfig(
+    service_name="my-api",
+    target_schema_version="1.1",   # default
+)
+```
+
+With `target_schema_version="1.1"`:
+
+- `schema_version` in emitted events is `"1.1"`
+- HTTP 401/403 produce `DENIED` with `error_type`
+- Events pass v1.1 schema validation (stricter bounds)
+
+### Step 3: Enable runtime validation
+
+For confidence during migration, turn on runtime validation to catch any
+events that would violate the target schema:
+
+```python
+config = AuditConfig(
+    service_name="my-api",
+    target_schema_version="1.1",
+    validate_events=True,
+    validation_failure_mode="log_and_emit",  # log but still emit
+)
+```
+
+Once stable, switch to `"drop"` (default) to silently discard bad events,
+or disable validation entirely for production throughput.
+
+## DENIED Outcome and Denial Reason Callback
+
+v1.1 introduces `DENIED` to distinguish "the system correctly refused access"
+from "something broke" (`FAILURE`).  By default, HTTP 401 and 403 produce
+`DENIED` with a generic `error_type` like `"HTTP403"`.
+
+To provide richer denial categories for compliance teams, configure a callback:
+
+```python
+from fastapi import Request
+
+def denial_reason(request: Request, exc_info):
+    if exc_info:
+        error_type = exc_info[0]
+        if "consent" in error_type.lower():
+            return "ConsentRequired"
+        if "role" in error_type.lower():
+            return "RoleDenied"
+    return None  # fall back to default
+
+config = AuditConfig(
+    service_name="my-api",
+    get_denial_reason=denial_reason,
+)
+```
+
+## Configurable Denied Status Codes
+
+By default, only 401 and 403 produce DENIED.  To add custom status codes:
+
+```python
+config = AuditConfig(
+    service_name="my-api",
+    denied_status_codes=frozenset({401, 403, 451}),
+)
+```
+
+## `owner_org_id` for Cross-Org Access Detection
+
+v1.1 adds `actor.owner_org_id` to the actor block.  Use it in your `get_actor`
+callback to flag cross-organization access:
+
+```python
+def get_actor(request: Request):
+    return {
+        "subject_id": request.state.user_id,
+        "subject_type": "human",
+        "org_id": request.state.user_org,
+        "owner_org_id": request.state.resource_org,
+    }
+```
+
+This enables queries like:
+
+```sql
+SELECT * FROM audit_events
+WHERE actor->>'org_id' != actor->>'owner_org_id';
+```

--- a/examples/access_denied_consent.json
+++ b/examples/access_denied_consent.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.1",
+  "event_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  "timestamp": "2026-03-30T14:10:00.000Z",
+  "service": {
+    "name": "records-api",
+    "environment": "prod",
+    "version": "1.8.2"
+  },
+  "actor": {
+    "subject_id": "user-therapist-17",
+    "subject_type": "human",
+    "org_id": "org-north",
+    "owner_org_id": "org-south",
+    "roles": ["therapist"]
+  },
+  "action": {
+    "type": "READ",
+    "data_classification": "PHI",
+    "phi_touched": false
+  },
+  "resource": {
+    "type": "TreatmentNote",
+    "id": "note-5432",
+    "patient_id": "patient-8888"
+  },
+  "http": {
+    "method": "GET",
+    "route_template": "/patients/{patient_id}/notes/{note_id}",
+    "status_code": 403
+  },
+  "outcome": {
+    "status": "DENIED",
+    "error_type": "ConsentRequired"
+  }
+}

--- a/examples/access_denied_role.json
+++ b/examples/access_denied_role.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.1",
+  "event_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "timestamp": "2026-03-30T14:05:00.000Z",
+  "service": {
+    "name": "clinical-api",
+    "environment": "prod",
+    "version": "3.1.0"
+  },
+  "actor": {
+    "subject_id": "user-clinician-42",
+    "subject_type": "human",
+    "org_id": "org-main",
+    "roles": ["clinician"]
+  },
+  "action": {
+    "type": "READ",
+    "data_classification": "PHI",
+    "phi_touched": false
+  },
+  "resource": {
+    "type": "Patient",
+    "id": "patient-9999",
+    "patient_id": "patient-9999"
+  },
+  "http": {
+    "method": "GET",
+    "route_template": "/patients/{patient_id}",
+    "status_code": 403
+  },
+  "outcome": {
+    "status": "DENIED",
+    "error_type": "RoleDenied"
+  }
+}

--- a/examples/cross_org_access_denied.json
+++ b/examples/cross_org_access_denied.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "1.1",
+  "event_id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+  "timestamp": "2026-03-30T14:15:00.000Z",
+  "service": {
+    "name": "data-exchange-api",
+    "environment": "prod",
+    "version": "2.0.0"
+  },
+  "actor": {
+    "subject_id": "svc-external-partner",
+    "subject_type": "service",
+    "org_id": "org-partner-east",
+    "owner_org_id": "org-main"
+  },
+  "action": {
+    "type": "EXPORT",
+    "data_classification": "PHI",
+    "phi_touched": false
+  },
+  "resource": {
+    "type": "PatientBundle",
+    "id": "bundle-1234",
+    "patient_id": "patient-7777"
+  },
+  "http": {
+    "method": "POST",
+    "route_template": "/export/patients/{patient_id}",
+    "status_code": 403
+  },
+  "outcome": {
+    "status": "DENIED",
+    "error_type": "CrossOrgAccessDenied"
+  },
+  "correlation": {
+    "request_id": "req-export-abc",
+    "trace_id": "1af7651916cd43dd8448eb211c80319d"
+  }
+}

--- a/examples/service_to_service.json
+++ b/examples/service_to_service.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "1.1",
+  "event_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "timestamp": "2026-03-30T14:00:00.000Z",
+  "service": {
+    "name": "scheduling-api",
+    "environment": "prod",
+    "version": "2.4.1"
+  },
+  "actor": {
+    "subject_id": "svc-intake-portal",
+    "subject_type": "service"
+  },
+  "action": {
+    "type": "READ",
+    "data_classification": "PHI"
+  },
+  "resource": {
+    "type": "Appointment",
+    "id": "appt-98765"
+  },
+  "http": {
+    "method": "GET",
+    "route_template": "/appointments/{appointment_id}",
+    "status_code": 200
+  },
+  "outcome": {
+    "status": "SUCCESS"
+  },
+  "correlation": {
+    "request_id": "req-aabb-ccdd",
+    "trace_id": "0af7651916cd43dd8448eb211c80319c"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bh-fastapi-audit"
-version = "0.3.0"
+version = "0.4.0"
 description = "FastAPI ASGI middleware for emitting PHI-safe audit events for behavioral healthcare systems"
 readme = "README.md"
 license = "Apache-2.0"
@@ -35,8 +35,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "fastapi>=0.100.0",
-    "pydantic>=2.0.0",
+    "fastapi>=0.100.0,<1",         # ASGI framework for middleware integration
+    "pydantic>=2.0.0,<3",          # Config validation (required by FastAPI)
+    "jsonschema>=4.20,<5",         # Runtime schema validation of audit events (v0.4)
 ]
 
 [project.optional-dependencies]
@@ -48,7 +49,7 @@ dev = [
     "mypy>=1.0.0",
 ]
 jsonschema = [
-    "jsonschema>=4.0.0",
+    "jsonschema>=4.20,<5",         # Now a core dep; this extra is a no-op but kept so existing pip install "pkg[jsonschema]" commands don't break
 ]
 sqlalchemy = [
     "sqlalchemy>=2.0.0",

--- a/src/bh_fastapi_audit/__init__.py
+++ b/src/bh_fastapi_audit/__init__.py
@@ -5,7 +5,7 @@ This package provides pure ASGI middleware for emitting structured audit events
 conforming to the bh-audit-schema v1.1 standard for behavioral healthcare systems.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from bh_fastapi_audit._queue import EmitQueue
 from bh_fastapi_audit._stats import AuditStats
@@ -23,6 +23,7 @@ from bh_fastapi_audit._types import (
     ResourceBlock,
     ServiceBlock,
 )
+from bh_fastapi_audit._validation import AuditValidationError, validate_event
 from bh_fastapi_audit.middleware import AuditConfig, AuditMiddleware
 from bh_fastapi_audit.redaction import (
     contains_phi_tokens,
@@ -42,6 +43,7 @@ __all__ = [
     "AuditConfig",
     "AuditMiddleware",
     "AuditStats",
+    "AuditValidationError",
     "EmitQueue",
     # Type definitions
     "ActionBlock",
@@ -62,6 +64,8 @@ __all__ = [
     "LoggingSink",
     "MemorySink",
     "SQLAlchemySink",
+    # Validation
+    "validate_event",
     # Redaction utilities
     "contains_phi_tokens",
     "redact_tokens",

--- a/src/bh_fastapi_audit/_stats.py
+++ b/src/bh_fastapi_audit/_stats.py
@@ -32,6 +32,7 @@ class AuditStats:
         "callback_failures_total",
         "events_dropped_total",
         "validation_failures_total",
+        "validation_time_ms_total",
     )
 
     def __init__(self) -> None:
@@ -41,13 +42,19 @@ class AuditStats:
         self.callback_failures_total: int = 0
         self.events_dropped_total: int = 0
         self.validation_failures_total: int = 0
+        self.validation_time_ms_total: float = 0.0
 
     def increment(self, name: _CounterName) -> None:
         """Atomically increment a named counter by 1."""
         with self._lock:
             setattr(self, name, getattr(self, name) + 1)
 
-    def snapshot(self) -> dict[str, int]:
+    def record_validation_time(self, ms: float) -> None:
+        """Add *ms* to the cumulative validation time counter."""
+        with self._lock:
+            self.validation_time_ms_total += ms
+
+    def snapshot(self) -> dict[str, int | float]:
         """Return a plain-dict copy of the current counter values."""
         with self._lock:
             return {
@@ -56,4 +63,5 @@ class AuditStats:
                 "callback_failures_total": self.callback_failures_total,
                 "events_dropped_total": self.events_dropped_total,
                 "validation_failures_total": self.validation_failures_total,
+                "validation_time_ms_total": self.validation_time_ms_total,
             }

--- a/src/bh_fastapi_audit/_validation.py
+++ b/src/bh_fastapi_audit/_validation.py
@@ -1,0 +1,57 @@
+"""
+Runtime JSON-schema validation for audit events.
+
+Provides lazy-loaded, version-aware validators so the cost of compiling
+the schema is paid at most once per schema version.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import jsonschema
+import jsonschema.validators
+
+from bh_fastapi_audit.schema import load_schema
+
+_VALIDATORS: dict[str, jsonschema.Draft202012Validator] = {}
+_VALIDATORS_LOCK = threading.Lock()
+
+
+class AuditValidationError(Exception):
+    """Raised when an audit event fails schema validation."""
+
+    def __init__(self, event_id: str | None, errors: list[str]) -> None:
+        self.event_id = event_id
+        self.errors = errors
+        summary = "; ".join(errors[:3])
+        super().__init__(f"Validation failed for event {event_id}: {summary}")
+
+
+def _get_validator(schema_version: str) -> jsonschema.Draft202012Validator:
+    """Return a compiled validator for *schema_version*, caching the result."""
+    if schema_version in _VALIDATORS:
+        return _VALIDATORS[schema_version]
+    with _VALIDATORS_LOCK:
+        if schema_version not in _VALIDATORS:
+            schema = load_schema(schema_version)
+            validator_cls = jsonschema.validators.validator_for(schema)
+            validator_cls.check_schema(schema)
+            _VALIDATORS[schema_version] = validator_cls(
+                schema,
+                format_checker=jsonschema.FormatChecker(),
+            )
+    return _VALIDATORS[schema_version]
+
+
+def validate_event(
+    event: dict[str, Any],
+    schema_version: str = "1.1",
+) -> list[str]:
+    """Validate *event* against the given *schema_version*.
+
+    Returns a list of human-readable error messages (empty on success).
+    """
+    validator = _get_validator(schema_version)
+    return [err.message for err in validator.iter_errors(event)]

--- a/src/bh_fastapi_audit/middleware.py
+++ b/src/bh_fastapi_audit/middleware.py
@@ -9,6 +9,7 @@ avoids known Starlette issues, and reduces per-request overhead.
 from __future__ import annotations
 
 import logging
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -30,7 +31,6 @@ from bh_fastapi_audit._types import (
     ServiceBlock,
 )
 from bh_fastapi_audit.redaction import sanitize_error_message
-from bh_fastapi_audit.schema import SCHEMA_VERSION
 from bh_fastapi_audit.sinks.base import AuditSink
 
 HTTP_METHOD_TO_ACTION: dict[str, str] = {
@@ -44,7 +44,14 @@ HTTP_METHOD_TO_ACTION: dict[str, str] = {
 
 _SCALAR_TYPES = (str, int, float, bool, type(None))
 _MAX_HEADER_VALUE_LENGTH = 256
-_DENIED_STATUS_CODES = frozenset({401, 403})
+
+
+class _AuditValidationRaise(Exception):
+    """Internal wrapper so validation_failure_mode="raise" escapes the finally block."""
+
+    def __init__(self, cause: Exception) -> None:
+        self.cause = cause
+        super().__init__(str(cause))
 
 
 @dataclass(frozen=True)
@@ -75,18 +82,28 @@ class AuditConfig:
     emit_mode: Literal["sync", "queue"] = "queue"
     queue_size: int = 10_000
     queue_drain_timeout: float = 5.0
+    validate_events: bool = False
+    validation_failure_mode: Literal["drop", "log_and_emit", "raise"] = "drop"
+    get_denial_reason: Callable[[Any, Any], str | None] | None = None
+    denied_status_codes: frozenset[int] = field(
+        default_factory=lambda: frozenset({401, 403}),
+    )
+    target_schema_version: Literal["1.0", "1.1"] = "1.1"
 
     def __post_init__(self) -> None:
         if isinstance(self.metadata_allowlist, set):
             object.__setattr__(self, "metadata_allowlist", frozenset(self.metadata_allowlist))
         if isinstance(self.excluded_paths, set):
             object.__setattr__(self, "excluded_paths", frozenset(self.excluded_paths))
+        if isinstance(self.denied_status_codes, set):
+            object.__setattr__(self, "denied_status_codes", frozenset(self.denied_status_codes))
 
 
 class AuditMiddleware:
     """Pure ASGI middleware that emits audit events for each HTTP request.
 
-    Events conform to bh-audit-schema v1.1.
+    Events conform to bh-audit-schema v1.0 or v1.1 depending on
+    ``AuditConfig.target_schema_version``.
 
     PHI Safety Guarantees:
     - Never reads or logs request/response bodies
@@ -169,6 +186,8 @@ class AuditMiddleware:
                     exc_info,
                 )
                 self._safe_emit(event)
+            except _AuditValidationRaise as wrap:
+                raise wrap.cause from wrap.cause
             except Exception:
                 self._stats.increment("emit_failures_total")
 
@@ -177,7 +196,50 @@ class AuditMiddleware:
     # ------------------------------------------------------------------
 
     def _safe_emit(self, event: dict[str, Any]) -> None:
-        """Emit via queue (non-blocking) or direct sink call."""
+        """Emit via queue (non-blocking) or direct sink call.
+
+        When ``validate_events`` is enabled, the event is checked against
+        the target schema version before reaching the sink.
+        """
+        if self.config.validate_events:
+            from bh_fastapi_audit._validation import AuditValidationError, validate_event
+
+            t0 = time.perf_counter()
+            errors = validate_event(event, self.config.target_schema_version)
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            self._stats.record_validation_time(elapsed_ms)
+
+            if errors:
+                self._stats.increment("validation_failures_total")
+                mode = self.config.validation_failure_mode
+
+                if mode == "raise":
+                    raise _AuditValidationRaise(AuditValidationError(event.get("event_id"), errors))
+
+                if mode == "drop":
+                    self._stats.increment("events_dropped_total")
+                    self._failure_log.warning(
+                        "Audit event dropped (validation): event_id=%s service=%s "
+                        "action=%s resource=%s error=%s",
+                        event.get("event_id"),
+                        event.get("service", {}).get("name"),
+                        event.get("action", {}).get("type"),
+                        event.get("resource", {}).get("type"),
+                        errors[0],
+                    )
+                    return
+
+                # log_and_emit: log the error but continue to emit
+                self._failure_log.warning(
+                    "Audit event validation failed (emitting anyway): event_id=%s "
+                    "service=%s action=%s resource=%s error=%s",
+                    event.get("event_id"),
+                    event.get("service", {}).get("name"),
+                    event.get("action", {}).get("type"),
+                    event.get("resource", {}).get("type"),
+                    errors[0],
+                )
+
         if self._queue is not None:
             self._queue.enqueue(event)
             return
@@ -215,7 +277,7 @@ class AuditMiddleware:
         request = Request(scope)
 
         event: AuditEvent = {
-            "schema_version": SCHEMA_VERSION,
+            "schema_version": self.config.target_schema_version,
             "event_id": str(uuid.uuid4()),
             "timestamp": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
             "service": self._build_service(),
@@ -223,7 +285,7 @@ class AuditMiddleware:
             "action": self._build_action(request),
             "resource": self._build_resource(request, status_code),
             "http": self._build_http(request, status_code, exc_info),
-            "outcome": self._build_outcome(status_code, exc_info),
+            "outcome": self._build_outcome(request, status_code, exc_info),
         }
 
         correlation = self._build_correlation(request)
@@ -331,27 +393,51 @@ class AuditMiddleware:
 
     def _build_outcome(
         self,
+        request: Request,
         status_code: int,
         exc_info: tuple[str, str, int] | None = None,
     ) -> OutcomeBlock:
+        denied_codes = self.config.denied_status_codes
+        downgrade_denied = self.config.target_schema_version == "1.0"
+
         if exc_info is not None:
             error_type, error_message, exc_status = exc_info
-            if exc_status in _DENIED_STATUS_CODES:
+            if exc_status in denied_codes:
+                denial_reason = self._try_denial_callback(request, exc_info)
+                resolved_type = denial_reason if denial_reason else error_type
+
+                if downgrade_denied:
+                    return {
+                        "status": "FAILURE",
+                        "error_type": resolved_type,
+                        "error_message": error_message,
+                    }
                 return {
                     "status": "DENIED",
-                    "error_type": error_type,
+                    "error_type": resolved_type,
                 }
+
             return {
                 "status": "FAILURE",
                 "error_type": error_type,
                 "error_message": error_message,
             }
 
-        if status_code in _DENIED_STATUS_CODES:
+        if status_code in denied_codes:
+            denial_reason = self._try_denial_callback(request, None)
+            resolved_type = denial_reason if denial_reason else f"HTTP{status_code}"
+
+            if downgrade_denied:
+                return {
+                    "status": "FAILURE",
+                    "error_type": resolved_type,
+                    "error_message": f"HTTP {status_code} response",
+                }
             return {
                 "status": "DENIED",
-                "error_type": f"HTTP{status_code}",
+                "error_type": resolved_type,
             }
+
         if status_code >= 400:
             return {
                 "status": "FAILURE",
@@ -359,6 +445,28 @@ class AuditMiddleware:
                 "error_message": f"HTTP {status_code} response",
             }
         return {"status": "SUCCESS"}
+
+    def _try_denial_callback(
+        self,
+        request: Request,
+        exc_info: tuple[str, str, int] | None,
+    ) -> str | None:
+        """Invoke the user-supplied denial-reason callback, if configured.
+
+        Returns the callback result on success, ``None`` on failure or
+        if no callback is configured.
+        """
+        if self.config.get_denial_reason is None:
+            return None
+        try:
+            return self.config.get_denial_reason(request, exc_info)
+        except Exception as exc:
+            self._stats.increment("callback_failures_total")
+            self._failure_log.warning(
+                "get_denial_reason callback failed: %s",
+                exc,
+            )
+            return None
 
     @staticmethod
     def _cap_header(value: str, maxlen: int = _MAX_HEADER_VALUE_LENGTH) -> str:

--- a/src/bh_fastapi_audit/schema/__init__.py
+++ b/src/bh_fastapi_audit/schema/__init__.py
@@ -1,8 +1,9 @@
 """
-Vendored bh-audit-schema v1.1 for offline validation.
+Vendored bh-audit-schema v1.0 and v1.1 for offline validation.
 
-The JSON schema is included in this package to enable validation
-without network access.
+The JSON schemas are included in this package to enable validation
+without network access.  Use ``get_schema_path(version)`` to resolve
+the correct file or ``load_schema(version)`` to get the parsed dict.
 """
 
 from __future__ import annotations
@@ -13,19 +14,27 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "1.1"
+VERSIONS_DIR = Path(__file__).parent / "versions"
 SCHEMA_PATH = Path(__file__).parent / "audit_event.schema.json"
 
 
-def get_schema_path() -> Path:
-    """Return the path to the vendored audit event schema."""
-    return SCHEMA_PATH
+def get_schema_path(version: str = "1.1") -> Path:
+    """Return the path to the vendored audit event schema for *version*.
 
-
-@lru_cache(maxsize=1)
-def load_schema() -> dict[str, Any]:
-    """Load and return the audit event schema as a dictionary.
-
-    The result is cached to avoid repeated disk reads.
+    Raises ``FileNotFoundError`` if the requested version is not vendored.
     """
-    with open(SCHEMA_PATH) as f:
+    path = VERSIONS_DIR / version / "audit_event.schema.json"
+    if not path.exists():
+        raise FileNotFoundError(f"No vendored schema for version {version!r} at {path}")
+    return path
+
+
+@lru_cache(maxsize=4)
+def load_schema(version: str = "1.1") -> dict[str, Any]:
+    """Load and return the audit event schema for *version* as a dictionary.
+
+    The result is cached per version to avoid repeated disk reads.
+    """
+    schema_path = get_schema_path(version)
+    with open(schema_path) as f:
         return json.load(f)

--- a/src/bh_fastapi_audit/schema/versions/1.0/audit_event.schema.json
+++ b/src/bh_fastapi_audit/schema/versions/1.0/audit_event.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bh-healthcare.github.io/bh-audit-schema/1.0/audit_event.schema.json",
+  "title": "BH Audit Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "timestamp",
+    "service",
+    "actor",
+    "action",
+    "resource",
+    "outcome"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Schema version for this audit event."
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 16,
+      "description": "Globally unique identifier for this audit event (UUID recommended)."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp when the audited action occurred."
+    },
+
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "environment": { "type": "string", "description": "prod|staging|dev etc." },
+        "version": { "type": "string", "description": "Service version/build identifier." }
+      }
+    },
+
+    "correlation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "request_id": { "type": "string" },
+        "trace_id": { "type": "string" },
+        "session_id": { "type": "string" }
+      },
+      "description": "Identifiers used to correlate events across services."
+    },
+
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_id", "subject_type"],
+      "properties": {
+        "subject_id": { "type": "string", "minLength": 1 },
+        "subject_type": {
+          "type": "string",
+          "enum": ["human", "service"],
+          "description": "Whether the actor is a human user or a service principal."
+        },
+        "org_id": { "type": "string" },
+        "roles": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional roles at time of access."
+        }
+      }
+    },
+
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"]
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional specific action name (e.g., 'verify_insurance', 'sign_bps')."
+        },
+        "phi_touched": {
+          "type": "boolean",
+          "description": "True if the action touches regulated PHI (behavioral health context)."
+        },
+        "data_classification": {
+          "type": "string",
+          "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+          "default": "UNKNOWN"
+        }
+      }
+    },
+
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "minLength": 1, "description": "E.g., Patient, Note, Encounter, Appointment, Program." },
+        "id": { "type": "string", "description": "Resource identifier if applicable." },
+        "patient_id": { "type": "string", "description": "Patient identifier if applicable. Recommended for PHI-touching actions." }
+      }
+    },
+
+    "http": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "method": { "type": "string" },
+        "route_template": { "type": "string", "description": "Template path, not raw path (e.g., /patients/{patient_id}/notes/{note_id})." },
+        "status_code": { "type": "integer" },
+        "client_ip": { "type": "string" },
+        "user_agent": { "type": "string" }
+      }
+    },
+
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "type": "string", "enum": ["SUCCESS", "FAILURE"] },
+        "error_type": { "type": "string" },
+        "error_message": {
+          "type": "string",
+          "description": "Sanitized error message. Must not contain PHI."
+        }
+      }
+    },
+
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "event_hash": { "type": "string" },
+        "prev_event_hash": { "type": "string" },
+        "hash_alg": { "type": "string", "description": "Optional (e.g., sha256)." }
+      },
+      "description": "Optional tamper-evident chaining fields."
+    },
+
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional safe metadata. Must not include raw PHI."
+    }
+  }
+}
+

--- a/src/bh_fastapi_audit/schema/versions/1.1/audit_event.schema.json
+++ b/src/bh_fastapi_audit/schema/versions/1.1/audit_event.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bh-healthcare.github.io/bh-audit-schema/1.1/audit_event.schema.json",
+  "title": "BH Audit Event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "timestamp",
+    "service",
+    "actor",
+    "action",
+    "resource",
+    "outcome"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.1",
+      "description": "Schema version for this audit event."
+    },
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "minLength": 36,
+      "maxLength": 36,
+      "description": "Globally unique UUID identifier for this audit event."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp when the audited action occurred."
+    },
+
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "environment": { "type": "string", "maxLength": 64, "description": "prod|staging|dev etc." },
+        "version": { "type": "string", "maxLength": 64, "description": "Service version/build identifier." }
+      }
+    },
+
+    "correlation": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "request_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "trace_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "session_id": { "type": "string", "minLength": 1, "maxLength": 256 }
+      },
+      "description": "Identifiers used to correlate events across services. At least one ID required if present."
+    },
+
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_id", "subject_type"],
+      "properties": {
+        "subject_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "subject_type": {
+          "type": "string",
+          "enum": ["human", "service"],
+          "description": "Whether the actor is a human user or a service principal."
+        },
+        "org_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "owner_org_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "description": "Organization that owns the resource being accessed. Enables cross-org access detection."
+        },
+        "roles": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "maxItems": 25,
+          "description": "Optional roles at time of access."
+        }
+      }
+    },
+
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"]
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "Optional specific action name (e.g., 'verify_insurance', 'sign_bps')."
+        },
+        "phi_touched": {
+          "type": "boolean",
+          "description": "True if the action touches regulated PHI (behavioral health context)."
+        },
+        "data_classification": {
+          "type": "string",
+          "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+          "default": "UNKNOWN"
+        }
+      }
+    },
+
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "minLength": 1, "maxLength": 128, "description": "E.g., Patient, Note, Encounter, Appointment, Program." },
+        "id": { "type": "string", "minLength": 1, "maxLength": 256, "description": "Resource identifier if applicable." },
+        "patient_id": { "type": "string", "minLength": 1, "maxLength": 256, "description": "Patient identifier if applicable. Recommended for PHI-touching actions." }
+      }
+    },
+
+    "http": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+        },
+        "route_template": { "type": "string", "maxLength": 512, "description": "Template path, not raw path (e.g., /patients/{patient_id}/notes/{note_id})." },
+        "status_code": { "type": "integer", "minimum": 100, "maximum": 599 },
+        "client_ip": {
+          "type": "string",
+          "anyOf": [
+            { "format": "ipv4" },
+            { "format": "ipv6" }
+          ],
+          "description": "Client IP address (IPv4 or IPv6)."
+        },
+        "user_agent": { "type": "string", "maxLength": 512 }
+      }
+    },
+
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "type": "string", "enum": ["SUCCESS", "FAILURE", "DENIED"] },
+        "error_type": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "error_message": {
+          "type": "string",
+          "maxLength": 500,
+          "description": "Sanitized error message. Must not contain PHI."
+        }
+      },
+      "description": "DENIED indicates the system correctly refused access (not an error). FAILURE indicates an operational error. Both FAILURE and DENIED require error_type. DENIED requires error_type to enable compliance and SOC teams to distinguish denial categories (role, cross-org, consent, etc.). error_message is optional on DENIED."
+    },
+
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "event_hash": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "prev_event_hash": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "hash_alg": {
+          "type": "string",
+          "enum": ["sha256", "sha384", "sha512"],
+          "description": "Hash algorithm used for tamper-evident chaining."
+        }
+      },
+      "dependentRequired": {
+        "event_hash": ["hash_alg"],
+        "prev_event_hash": ["hash_alg", "event_hash"]
+      },
+      "description": "Optional tamper-evident chaining fields."
+    },
+
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "integer", "number", "boolean", "null"]
+      },
+      "maxProperties": 20,
+      "description": "Optional safe metadata. Values must be scalar (no nested objects or arrays). Must not include raw PHI."
+    }
+  },
+
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "properties": { "status": { "const": "FAILURE" } },
+            "required": ["status"]
+          }
+        },
+        "required": ["outcome"]
+      },
+      "then": {
+        "properties": {
+          "outcome": {
+            "required": ["status", "error_type", "error_message"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "properties": { "status": { "const": "DENIED" } },
+            "required": ["status"]
+          }
+        },
+        "required": ["outcome"]
+      },
+      "then": {
+        "properties": {
+          "outcome": {
+            "required": ["status", "error_type"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+"""
+Shared test fixtures for bh-fastapi-audit.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bh_fastapi_audit import AuditConfig, AuditMiddleware, MemorySink
+
+
+def make_test_event(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal valid v1.1 audit event, with optional overrides."""
+    event: dict[str, Any] = {
+        "schema_version": "1.1",
+        "event_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "service": {"name": "test-svc", "environment": "test"},
+        "actor": {"subject_id": "user-1", "subject_type": "human"},
+        "action": {"type": "READ", "data_classification": "UNKNOWN"},
+        "resource": {"type": "TestResource"},
+        "outcome": {"status": "SUCCESS"},
+    }
+    event.update(overrides)
+    return event
+
+
+@pytest.fixture()
+def memory_sink() -> MemorySink:
+    """Fresh MemorySink instance."""
+    return MemorySink()
+
+
+def audit_config(**overrides: Any) -> AuditConfig:
+    """Factory that returns an AuditConfig with sensible test defaults."""
+    defaults: dict[str, Any] = {
+        "service_name": "test-service",
+        "service_environment": "test",
+        "service_version": "1.0.0",
+        "emit_mode": "sync",
+    }
+    defaults.update(overrides)
+    return AuditConfig(**defaults)
+
+
+def _find_middleware(app: Any) -> AuditMiddleware | None:
+    """Walk a Starlette/FastAPI ASGI stack and return the AuditMiddleware."""
+    current = app
+    while current is not None:
+        if isinstance(current, AuditMiddleware):
+            return current
+        current = getattr(current, "app", None)
+    return None
+
+
+def build_app(
+    config: AuditConfig,
+    sink: MemorySink,
+) -> tuple[TestClient, MemorySink, AuditMiddleware]:
+    """Build a FastAPI app with the given config + sink, return (client, sink, mw)."""
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware, sink=sink, config=config)
+
+    @app.get("/items/{item_id}")
+    def get_item(item_id: str) -> dict[str, str]:
+        return {"item_id": item_id}
+
+    @app.post("/items")
+    def create_item() -> dict[str, bool]:
+        return {"created": True}
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # Force Starlette to build the middleware stack by making a request
+    # to an excluded path (no audit event emitted).
+    client.get("/health")
+
+    mw = _find_middleware(app.middleware_stack)
+    assert mw is not None, "AuditMiddleware not found on app stack"
+    return client, sink, mw

--- a/tests/test_denied_outcome.py
+++ b/tests/test_denied_outcome.py
@@ -1,0 +1,241 @@
+"""
+Tests for DENIED outcome, denial callbacks, and configurable denied status codes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from bh_fastapi_audit import AuditConfig, AuditMiddleware, MemorySink
+from bh_fastapi_audit._validation import validate_event
+from tests.conftest import audit_config
+
+
+def _find_middleware(app: Any) -> AuditMiddleware | None:
+    """Walk a Starlette/FastAPI ASGI stack and return the AuditMiddleware."""
+    current = app
+    while current is not None:
+        if isinstance(current, AuditMiddleware):
+            return current
+        current = getattr(current, "app", None)
+    return None
+
+
+def _make_status_app(
+    config: AuditConfig,
+    sink: MemorySink,
+) -> tuple[TestClient, MemorySink, AuditMiddleware]:
+    """App with endpoints returning various status codes."""
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware, sink=sink, config=config)
+
+    @app.get("/ok")
+    def ok() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/forbidden")
+    def forbidden() -> None:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    @app.get("/unauthorized")
+    def unauthorized() -> None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    @app.get("/not-found")
+    def not_found() -> None:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    @app.get("/server-error")
+    def server_error() -> None:
+        raise HTTPException(status_code=500, detail="Internal Server Error")
+
+    @app.get("/consent-denied")
+    def consent_denied() -> None:
+        raise HTTPException(status_code=403, detail="ConsentRequired: patient did not consent")
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.get("/health")
+
+    mw = _find_middleware(app.middleware_stack)
+    assert mw is not None, "AuditMiddleware not found on app stack"
+    return client, sink, mw
+
+
+class TestDeniedOutcome:
+    def test_403_produces_denied(self) -> None:
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/forbidden")
+
+        assert len(sink) == 1
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "DENIED"
+
+    def test_401_produces_denied(self) -> None:
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/unauthorized")
+
+        assert len(sink) == 1
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "DENIED"
+
+    def test_403_denied_has_error_type(self) -> None:
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/forbidden")
+
+        event = sink.events[0]
+        assert "error_type" in event["outcome"]
+        assert event["outcome"]["error_type"] == "HTTP403"
+
+    def test_200_produces_success(self) -> None:
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/ok")
+
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "SUCCESS"
+
+    def test_500_produces_failure(self) -> None:
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/server-error")
+
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "FAILURE"
+        assert "error_type" in event["outcome"]
+        assert "error_message" in event["outcome"]
+
+
+class TestDenialCallback:
+    def test_custom_denial_reason_callback(self) -> None:
+        def denial_reason(request: Any, exc_info: Any) -> str | None:
+            return "CustomDenialReason"
+
+        cfg = audit_config(get_denial_reason=denial_reason)
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/forbidden")
+
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "DENIED"
+        assert event["outcome"]["error_type"] == "CustomDenialReason"
+
+    def test_denial_callback_failure_falls_back(self) -> None:
+        def bad_callback(request: Any, exc_info: Any) -> str | None:
+            raise ValueError("callback broke")
+
+        cfg = audit_config(get_denial_reason=bad_callback)
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/forbidden")
+
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "DENIED"
+        assert event["outcome"]["error_type"] == "HTTP403"
+        assert mw.stats.callback_failures_total >= 1
+
+    def test_denial_callback_none_uses_default(self) -> None:
+        def returns_none(request: Any, exc_info: Any) -> str | None:
+            return None
+
+        cfg = audit_config(get_denial_reason=returns_none)
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/forbidden")
+
+        event = sink.events[0]
+        assert event["outcome"]["error_type"] == "HTTP403"
+
+
+class TestConfigurableDeniedStatusCodes:
+    def test_configurable_denied_status_codes(self) -> None:
+        cfg = audit_config(denied_status_codes=frozenset({401, 403, 451}))
+        sink = MemorySink()
+        app = FastAPI()
+        app.add_middleware(AuditMiddleware, sink=sink, config=cfg)
+
+        @app.get("/legal-block")
+        def legal_block() -> None:
+            raise HTTPException(status_code=451, detail="Unavailable For Legal Reasons")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        client.get("/legal-block")
+
+        assert len(sink) == 1
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "DENIED"
+
+    def test_404_not_denied_by_default(self) -> None:
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/not-found")
+
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "FAILURE"
+
+
+class TestDeniedWithErrorMessage:
+    def test_denied_with_error_message(self) -> None:
+        """DENIED outcome from exc_info should carry error_type."""
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/consent-denied")
+
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "DENIED"
+        assert "error_type" in event["outcome"]
+
+    def test_failure_always_has_error_type_and_message(self) -> None:
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/server-error")
+
+        event = sink.events[0]
+        outcome = event["outcome"]
+        assert outcome["status"] == "FAILURE"
+        assert "error_type" in outcome
+        assert "error_message" in outcome
+
+
+class TestDeniedSchemaCompliance:
+    def test_denied_emitted_events_pass_schema(self) -> None:
+        cfg = audit_config()
+        sink = MemorySink()
+        client, sink, mw = _make_status_app(cfg, sink)
+
+        client.get("/forbidden")
+        client.get("/unauthorized")
+        client.get("/ok")
+        client.get("/server-error")
+
+        for event in sink.events:
+            errors = validate_event(event, schema_version="1.1")
+            assert errors == [], f"Event {event['event_id']} failed: {errors}"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -12,6 +12,7 @@ def test_public_api_imports():
         AuditConfig,
         AuditMiddleware,
         AuditSink,
+        AuditValidationError,
         EmitQueue,
         JsonlFileSink,
         LoggingSink,
@@ -19,11 +20,13 @@ def test_public_api_imports():
         contains_phi_tokens,
         redact_tokens,
         sanitize_error_message,
+        validate_event,
     )
 
     assert AuditMiddleware is not None
     assert AuditConfig is not None
     assert AuditSink is not None
+    assert AuditValidationError is not None
     assert MemorySink is not None
     assert JsonlFileSink is not None
     assert LoggingSink is not None
@@ -31,6 +34,7 @@ def test_public_api_imports():
     assert callable(sanitize_error_message)
     assert callable(contains_phi_tokens)
     assert callable(redact_tokens)
+    assert callable(validate_event)
 
 
 def test_typed_event_blocks_importable():
@@ -82,7 +86,7 @@ def test_version_exposed():
     from bh_fastapi_audit import __version__
 
     assert isinstance(__version__, str)
-    assert __version__ == "0.3.0"
+    assert __version__ == "0.4.0"
 
 
 def test_all_exports_defined():
@@ -94,6 +98,7 @@ def test_all_exports_defined():
         "AuditConfig",
         "AuditMiddleware",
         "AuditStats",
+        "AuditValidationError",
         "EmitQueue",
         # Types
         "ActionBlock",
@@ -114,6 +119,8 @@ def test_all_exports_defined():
         "LoggingSink",
         "MemorySink",
         "SQLAlchemySink",
+        # Validation
+        "validate_event",
         # Redaction
         "contains_phi_tokens",
         "redact_tokens",

--- a/tests/test_schema_negotiation.py
+++ b/tests/test_schema_negotiation.py
@@ -1,0 +1,140 @@
+"""
+Tests for schema negotiation via target_schema_version.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from bh_fastapi_audit import AuditConfig, AuditMiddleware, MemorySink
+from bh_fastapi_audit._validation import validate_event
+from tests.conftest import audit_config
+
+
+def _find_middleware(app: Any) -> AuditMiddleware | None:
+    """Walk a Starlette/FastAPI ASGI stack and return the AuditMiddleware."""
+    current = app
+    while current is not None:
+        if isinstance(current, AuditMiddleware):
+            return current
+        current = getattr(current, "app", None)
+    return None
+
+
+def _make_app(
+    config: AuditConfig,
+    sink: MemorySink,
+) -> tuple[TestClient, MemorySink, AuditMiddleware]:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware, sink=sink, config=config)
+
+    @app.get("/ok")
+    def ok() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/forbidden")
+    def forbidden() -> None:
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.get("/health")
+
+    mw = _find_middleware(app.middleware_stack)
+    assert mw is not None, "AuditMiddleware not found on app stack"
+    return client, sink, mw
+
+
+class TestSchemaVersionEmission:
+    def test_target_1_0_emits_schema_version_1_0(self) -> None:
+        cfg = audit_config(target_schema_version="1.0")
+        sink = MemorySink()
+        client, sink, mw = _make_app(cfg, sink)
+
+        client.get("/ok")
+
+        event = sink.events[0]
+        assert event["schema_version"] == "1.0"
+
+    def test_target_1_1_emits_schema_version_1_1(self) -> None:
+        cfg = audit_config(target_schema_version="1.1")
+        sink = MemorySink()
+        client, sink, mw = _make_app(cfg, sink)
+
+        client.get("/ok")
+
+        event = sink.events[0]
+        assert event["schema_version"] == "1.1"
+
+
+class TestDeniedDowngrade:
+    def test_target_1_0_downgrades_denied_to_failure(self) -> None:
+        cfg = audit_config(target_schema_version="1.0")
+        sink = MemorySink()
+        client, sink, mw = _make_app(cfg, sink)
+
+        client.get("/forbidden")
+
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "FAILURE"
+        assert "error_type" in event["outcome"]
+        assert "error_message" in event["outcome"]
+
+    def test_target_1_1_emits_denied(self) -> None:
+        cfg = audit_config(target_schema_version="1.1")
+        sink = MemorySink()
+        client, sink, mw = _make_app(cfg, sink)
+
+        client.get("/forbidden")
+
+        event = sink.events[0]
+        assert event["outcome"]["status"] == "DENIED"
+
+
+class TestSchemaValidation:
+    def test_target_1_0_events_pass_1_0_schema(self) -> None:
+        cfg = audit_config(target_schema_version="1.0")
+        sink = MemorySink()
+        client, sink, mw = _make_app(cfg, sink)
+
+        client.get("/ok")
+        client.get("/forbidden")
+
+        for event in sink.events:
+            errors = validate_event(event, schema_version="1.0")
+            assert errors == [], f"v1.0 validation failed: {errors}"
+
+    def test_target_1_1_events_pass_1_1_schema(self) -> None:
+        cfg = audit_config(target_schema_version="1.1")
+        sink = MemorySink()
+        client, sink, mw = _make_app(cfg, sink)
+
+        client.get("/ok")
+        client.get("/forbidden")
+
+        for event in sink.events:
+            errors = validate_event(event, schema_version="1.1")
+            assert errors == [], f"v1.1 validation failed: {errors}"
+
+    def test_validation_uses_matching_schema(self) -> None:
+        """When validate_events=True, validation uses the target version."""
+        cfg = audit_config(
+            validate_events=True,
+            target_schema_version="1.0",
+            validation_failure_mode="log_and_emit",
+        )
+        sink = MemorySink()
+        client, sink, mw = _make_app(cfg, sink)
+
+        client.get("/ok")
+
+        assert len(sink) == 1
+        event = sink.events[0]
+        assert event["schema_version"] == "1.0"
+        assert mw.stats.validation_time_ms_total > 0

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,204 @@
+"""
+Tests for _validation.py (unit) and middleware validation wiring (integration).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bh_fastapi_audit import AuditMiddleware, MemorySink
+from bh_fastapi_audit._validation import validate_event
+from tests.conftest import audit_config, build_app, make_test_event
+
+# ---------------------------------------------------------------
+# Unit tests for validate_event
+# ---------------------------------------------------------------
+
+
+class TestValidateEventUnit:
+    def test_valid_event_passes(self) -> None:
+        event = make_test_event()
+        errors = validate_event(event, schema_version="1.1")
+        assert errors == []
+
+    def test_missing_required_field(self) -> None:
+        event = make_test_event()
+        del event["actor"]
+        errors = validate_event(event, schema_version="1.1")
+        assert len(errors) > 0
+        assert any("actor" in e for e in errors)
+
+    def test_failure_without_error_type(self) -> None:
+        event = make_test_event(
+            outcome={"status": "FAILURE"},
+        )
+        errors = validate_event(event, schema_version="1.1")
+        assert len(errors) > 0
+
+    def test_denied_without_error_type(self) -> None:
+        event = make_test_event(
+            outcome={"status": "DENIED"},
+        )
+        errors = validate_event(event, schema_version="1.1")
+        assert len(errors) > 0
+
+    def test_metadata_nested_object_fails(self) -> None:
+        event = make_test_event(
+            metadata={"nested": {"a": 1}},
+        )
+        errors = validate_event(event, schema_version="1.1")
+        assert len(errors) > 0
+
+    def test_empty_correlation_fails(self) -> None:
+        event = make_test_event(correlation={})
+        errors = validate_event(event, schema_version="1.1")
+        assert len(errors) > 0
+
+
+# ---------------------------------------------------------------
+# Integration tests for middleware validation wiring
+# ---------------------------------------------------------------
+
+
+class TestMiddlewareValidationWiring:
+    def test_validate_events_false_skips(self) -> None:
+        """When validate_events=False, no validation overhead occurs."""
+        cfg = audit_config(validate_events=False)
+        sink = MemorySink()
+        client, sink, mw = build_app(cfg, sink)
+
+        client.get("/items/1")
+
+        assert len(sink) == 1
+        assert mw.stats.validation_failures_total == 0
+        assert mw.stats.validation_time_ms_total == 0.0
+
+    def test_drop_mode_increments_counters(self) -> None:
+        """In drop mode, invalid events are dropped and counters incremented."""
+        cfg = audit_config(
+            validate_events=True,
+            validation_failure_mode="drop",
+            target_schema_version="1.1",
+        )
+        sink = MemorySink()
+        client, sink, mw = build_app(cfg, sink)
+
+        client.get("/items/1")
+        assert len(sink) == 0 or mw.stats.validation_failures_total == 0
+
+        # Either the event was valid and emitted, or failed and was dropped.
+        # The default app emits valid 1.1 events, so it should pass.
+        if mw.stats.validation_failures_total == 0:
+            assert len(sink) == 1
+        else:
+            assert mw.stats.events_dropped_total > 0
+
+    def test_log_and_emit_mode_still_emits(self) -> None:
+        """In log_and_emit mode, events are emitted even if validation fails."""
+        cfg = audit_config(
+            validate_events=True,
+            validation_failure_mode="log_and_emit",
+        )
+        sink = MemorySink()
+        client, sink, mw = build_app(cfg, sink)
+
+        client.get("/items/1")
+
+        assert len(sink) == 1
+        assert mw.stats.validation_time_ms_total > 0
+
+    def test_raise_mode_raises_on_valid_event(self) -> None:
+        """With raise mode, valid events pass through without raising."""
+        cfg = audit_config(
+            validate_events=True,
+            validation_failure_mode="raise",
+            target_schema_version="1.1",
+        )
+        sink = MemorySink()
+        client, sink, mw = build_app(cfg, sink)
+
+        client.get("/items/1")
+
+        assert len(sink) == 1
+        assert mw.stats.validation_failures_total == 0
+
+    def test_raise_mode_raises_on_invalid_event(self) -> None:
+        """With raise mode, AuditValidationError escapes the finally block.
+
+        We monkey-patch _build_event to produce an invalid event and prove
+        that AuditValidationError propagates to the caller.
+        """
+        import pytest
+
+        from bh_fastapi_audit._validation import AuditValidationError
+
+        cfg = audit_config(
+            validate_events=True,
+            validation_failure_mode="raise",
+            target_schema_version="1.1",
+        )
+        sink = MemorySink()
+        app = FastAPI()
+        app.add_middleware(AuditMiddleware, sink=sink, config=cfg)
+
+        @app.get("/items/{item_id}")
+        def get_item(item_id: str) -> dict[str, str]:
+            return {"item_id": item_id}
+
+        client = TestClient(app, raise_server_exceptions=True)
+
+        client.get("/items/1")
+        assert len(sink) == 1
+
+        mw = None
+        current = app.middleware_stack
+        while current is not None:
+            if isinstance(current, AuditMiddleware):
+                mw = current
+                break
+            current = getattr(current, "app", None)
+        assert mw is not None
+
+        original_build = mw._build_event
+
+        def _bad_build(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            event = original_build(*args, **kwargs)
+            del event["actor"]
+            return event
+
+        mw._build_event = _bad_build  # type: ignore[assignment]
+
+        with pytest.raises(AuditValidationError) as exc_info:
+            client.get("/items/2")
+
+        assert "actor" in str(exc_info.value)
+        assert len(sink) == 1  # second request's event was NOT emitted
+
+    def test_validation_timing_recorded(self) -> None:
+        cfg = audit_config(validate_events=True)
+        sink = MemorySink()
+        client, sink, mw = build_app(cfg, sink)
+
+        client.get("/items/1")
+
+        snap = mw.stats.snapshot()
+        assert snap["validation_time_ms_total"] > 0
+
+    def test_validation_uses_target_schema_version(self) -> None:
+        """Validation should use the configured schema version."""
+        cfg = audit_config(
+            validate_events=True,
+            target_schema_version="1.0",
+            validation_failure_mode="log_and_emit",
+        )
+        sink = MemorySink()
+        client, sink, mw = build_app(cfg, sink)
+
+        client.get("/items/1")
+
+        assert len(sink) == 1
+        event = sink.events[0]
+        assert event["schema_version"] == "1.0"


### PR DESCRIPTION
v0.4.0 — Runtime schema validation, DENIED outcomes, schema version negotiation

- Add runtime schema validation with configurable failure modes (drop/log_and_emit/raise)
- Add DENIED outcome support with configurable denied_status_codes and get_denial_reason callback
- Add target_schema_version for backward-compatible event emission (1.0/1.1)
- Add validation_time_ms_total timing metric
- Vendor v1.0 and v1.1 schemas with thread-safe validator caching
- Add migration guide, examples, and 175+ tests