### PR TITLE
DynamoDBSink with table design, GSI queries, TTL, optional boto3 dependency, full moto test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`DynamoDBSink`** — production-grade audit sink for AWS DynamoDB (`pip install
+  bh-fastapi-audit[dynamodb]`).  Single-table design with `service#date` partition
+  key and `timestamp#event_id` sort key, optimized for time-range queries per service.
+  - Three Global Secondary Indexes for compliance queries:
+    - `patient_id-index` — all access to a given patient (HIPAA §164.312(b))
+    - `actor-index` — all actions by a given user (HIPAA §164.308(a)(1)(ii)(D))
+    - `outcome-index` — all DENIED/FAILED outcomes (HIPAA §164.308(a)(5)(ii)(C))
+  - `query_by_patient()`, `query_by_actor()`, `query_denials()` convenience methods
+    with optional time-range filtering.
+  - TTL-based retention (default 2190 days ≈ 6 years for HIPAA), disable with
+    `ttl_days=None`.
+  - Conditional PutItem on `event_id` prevents duplicate writes (idempotent).
+  - Full event stored as compact JSON in `event_json` attribute for archival/replay.
+  - Key fields (actor, action, resource, outcome, HTTP) flattened to top-level
+    DynamoDB attributes for GSI projections.
+  - `create_table=True` convenience flag for dev/test (creates table + GSIs).
+  - `boto3` is an **optional dependency** — guarded import, same pattern as
+    `SQLAlchemySink`.
+- **`[dynamodb]` optional extra** — `pip install bh-fastapi-audit[dynamodb]` installs
+  `boto3>=1.34,<2`.
+- **`moto[dynamodb]`** added to `[dev]` extras for DynamoDB test mocking.
+
 ## [0.4.0] - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`[dynamodb]` optional extra** — `pip install bh-fastapi-audit[dynamodb]` installs
   `boto3>=1.34,<2`.
 - **`moto[dynamodb]`** added to `[dev]` extras for DynamoDB test mocking.
+- **`docs/deploying-dynamodb.md`** — deployment guide covering Terraform provisioning,
+  IAM policy setup, environment variable configuration, table design reference,
+  failure handling, and cost estimates for production DynamoDB deployments.
 
 ## [0.4.0] - 2026-03-30
 

--- a/docs/deploying-dynamodb.md
+++ b/docs/deploying-dynamodb.md
@@ -1,0 +1,232 @@
+# Deploying DynamoDBSink to AWS
+
+This guide covers everything you need to run `DynamoDBSink` against a real AWS DynamoDB table in dev, staging, and production.
+
+## Quick Start (Local Development)
+
+For local development, use DynamoDB Local with `create_table=True`:
+
+```bash
+# Start DynamoDB Local
+docker run -d -p 8000:8000 amazon/dynamodb-local
+
+# Or use the docker-compose.yml in the examples repo:
+cd bh-fastapi-examples/dynamodb_audit_app
+docker compose up -d
+```
+
+```python
+from bh_fastapi_audit.sinks.dynamodb import DynamoDBSink
+
+sink = DynamoDBSink(
+    table_name="bh_audit_events",
+    region="us-east-1",
+    create_table=True,   # Creates table + GSIs automatically
+)
+```
+
+**Never use `create_table=True` in production.** The table should be provisioned via IaC (Terraform, CloudFormation, CDK).
+
+---
+
+## Production Setup
+
+### Step 1: Provision the DynamoDB Table
+
+Use the Terraform module in `bh-fastapi-examples/dynamodb_audit_app/terraform/`:
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars for your environment
+
+terraform init
+terraform plan
+terraform apply
+```
+
+This creates:
+
+| Resource | Purpose |
+|---|---|
+| `aws_dynamodb_table.audit_events` | The audit events table with 3 GSIs |
+| `aws_iam_policy.audit_writer` | Minimum IAM policy for the application |
+
+The table is created with:
+
+- **PAY_PER_REQUEST** billing (on-demand, no capacity planning needed)
+- **Server-side encryption** (AWS-owned key)
+- **Point-in-time recovery** enabled
+- **TTL** enabled on the `ttl` attribute
+- **3 GSIs** for compliance queries
+
+If you don't use Terraform, create the table manually or via CloudFormation with the schema described in the [Table Design](#table-design) section below.
+
+### Step 2: Attach the IAM Policy
+
+Attach the `bh-audit-dynamodb-writer-{env}` policy to your application's IAM role (ECS task role, Lambda execution role, EC2 instance profile, etc.):
+
+```bash
+# Get the policy ARN from Terraform output
+terraform output writer_policy_arn
+
+# Attach to your application role
+aws iam attach-role-policy \
+  --role-name your-app-role \
+  --policy-arn arn:aws:iam::123456789012:policy/bh-audit-dynamodb-writer-prod
+```
+
+### Step 3: Configure the Application
+
+The sink needs two pieces of information at runtime: the **table name** and the **AWS region**. Pass them via environment variables or constructor arguments.
+
+**Environment variables (recommended for containers/Lambda):**
+
+```bash
+export BH_AUDIT_TABLE=bh_audit_events
+export AWS_DEFAULT_REGION=us-east-1
+
+# AWS credentials come from the IAM role automatically in ECS/Lambda/EC2.
+# For local development with real AWS:
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+**In your FastAPI app:**
+
+```python
+import os
+from bh_fastapi_audit import AuditConfig, AuditMiddleware
+from bh_fastapi_audit.sinks.dynamodb import DynamoDBSink
+
+sink = DynamoDBSink(
+    table_name=os.environ.get("BH_AUDIT_TABLE", "bh_audit_events"),
+    region=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+    ttl_days=2190,          # ~6 years, HIPAA retention
+    create_table=False,     # Table provisioned via Terraform
+)
+
+config = AuditConfig(
+    service_name="your-service",
+    service_environment=os.environ.get("ENVIRONMENT", "dev"),
+    emit_failure_mode="log",   # Never break requests on DynamoDB failures
+    # ... other config
+)
+
+app.add_middleware(AuditMiddleware, sink=sink, config=config)
+```
+
+---
+
+## IAM Permissions
+
+The minimum IAM policy for the application:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AuditEventWrite",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:PutItem",
+        "dynamodb:DescribeTable"
+      ],
+      "Resource": "arn:aws:dynamodb:REGION:ACCOUNT:table/bh_audit_events"
+    },
+    {
+      "Sid": "AuditEventQuery",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:Query"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:REGION:ACCOUNT:table/bh_audit_events",
+        "arn:aws:dynamodb:REGION:ACCOUNT:table/bh_audit_events/index/*"
+      ]
+    }
+  ]
+}
+```
+
+Replace `REGION` and `ACCOUNT` with your values. If you only write events (no query endpoints), you can drop the `AuditEventQuery` statement entirely.
+
+**Do not grant `dynamodb:CreateTable` or `dynamodb:DeleteTable` to production roles.**
+
+---
+
+## Table Design
+
+The table uses a single-table design optimized for healthcare compliance queries.
+
+### Primary Key
+
+| Key | Attribute | Type | Format | Example |
+|---|---|---|---|---|
+| Partition Key | `service_date` | String | `{service_name}#{date}` | `intake-api#2026-04-15` |
+| Sort Key | `ts_event` | String | `{timestamp}#{event_id}` | `2026-04-15T14:32:07.123Z#c1d2e3f4-...` |
+
+**Why `service#date`?** All events for a service on a given day are co-located, making time-range queries within a day efficient. Cross-day queries require multiple partition reads, which is acceptable for infrequent compliance queries.
+
+### Global Secondary Indexes
+
+| GSI | PK | SK | Use Case | HIPAA Reference |
+|---|---|---|---|---|
+| `patient_id-index` | `patient_id` | `timestamp` | All access to patient X | §164.312(b) |
+| `actor-index` | `actor_subject_id` | `timestamp` | All actions by user Y | §164.308(a)(1)(ii)(D) |
+| `outcome-index` | `outcome_status` | `timestamp` | All DENIED/FAILED attempts | §164.308(a)(5)(ii)(C) |
+
+### TTL
+
+The `ttl` attribute is a Unix epoch timestamp set to `event_timestamp + ttl_days * 86400`. DynamoDB automatically deletes expired items at no cost. The default is 2190 days (~6 years) to satisfy HIPAA retention requirements.
+
+To disable TTL, pass `ttl_days=None` to the sink constructor.
+
+---
+
+## Configuration Reference
+
+| Parameter | Constructor arg | Env var | Default | Description |
+|---|---|---|---|---|
+| Table name | `table_name` | `BH_AUDIT_TABLE` | `bh_audit_events` | DynamoDB table name |
+| Region | `region` | `AWS_DEFAULT_REGION` | boto3 default | AWS region |
+| TTL days | `ttl_days` | — | `2190` (~6 years) | Days until auto-deletion. `None` to disable. |
+| Create table | `create_table` | — | `False` | Create table on init. **Dev/test only.** |
+
+AWS credentials are resolved by the standard boto3 credential chain:
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+2. Shared credentials file (`~/.aws/credentials`)
+3. AWS config file (`~/.aws/config`)
+4. IAM role for Amazon EC2 / ECS / Lambda (automatic in AWS compute)
+
+---
+
+## Failure Handling
+
+DynamoDB writes can fail (throttling, network issues, service outage). The `DynamoDBSink` is designed to work with the middleware's `emit_failure_mode` setting:
+
+| Mode | Behavior on DynamoDB failure |
+|---|---|
+| `"log"` (default) | Log a warning, increment `emit_failures_total`, continue serving |
+| `"silent"` | Silently drop, increment counter |
+| `"raise"` | Raise the exception (not recommended in production) |
+
+The middleware wraps all sink calls in `_safe_emit()`, so a DynamoDB outage **never crashes your application**. Monitor `stats.snapshot()["emit_failures_total"]` to detect sink issues.
+
+---
+
+## Cost Estimates
+
+For a typical BH Healthcare deployment (100-500 patients):
+
+| Metric | Estimate |
+|---|---|
+| Daily events | 500 - 2,000 |
+| Average event size | ~1.5 KB |
+| Monthly storage | ~30 - 90 MB |
+| 6-year retention | ~2 - 6.5 GB |
+| Monthly cost (on-demand) | < $2/month |
+
+This is well within DynamoDB free-tier territory for the first year.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,17 @@ dev = [
     "httpx>=0.24.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "moto[dynamodb]>=5.0,<6",      # AWS service mocking for DynamoDB tests
+    "boto3>=1.34,<2",              # Needed at test time for DynamoDB sink tests
 ]
 jsonschema = [
     "jsonschema>=4.20,<5",         # Now a core dep; this extra is a no-op but kept so existing pip install "pkg[jsonschema]" commands don't break
 ]
 sqlalchemy = [
     "sqlalchemy>=2.0.0",
+]
+dynamodb = [
+    "boto3>=1.34,<2",              # AWS SDK for DynamoDB audit sink
 ]
 
 [project.urls]
@@ -61,6 +66,7 @@ Documentation = "https://github.com/bh-healthcare/bh-fastapi-audit#readme"
 Repository = "https://github.com/bh-healthcare/bh-fastapi-audit"
 Issues = "https://github.com/bh-healthcare/bh-fastapi-audit/issues"
 Changelog = "https://github.com/bh-healthcare/bh-fastapi-audit/blob/main/CHANGELOG.md"
+Author = "https://tanmayakumar.com"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/bh_fastapi_audit"]

--- a/src/bh_fastapi_audit/__init__.py
+++ b/src/bh_fastapi_audit/__init__.py
@@ -32,6 +32,7 @@ from bh_fastapi_audit.redaction import (
 )
 from bh_fastapi_audit.sinks import (
     AuditSink,
+    DynamoDBSink,
     JsonlFileSink,
     LoggingSink,
     MemorySink,
@@ -60,6 +61,7 @@ __all__ = [
     "ServiceBlock",
     # Sinks
     "AuditSink",
+    "DynamoDBSink",
     "JsonlFileSink",
     "LoggingSink",
     "MemorySink",

--- a/src/bh_fastapi_audit/sinks/__init__.py
+++ b/src/bh_fastapi_audit/sinks/__init__.py
@@ -15,8 +15,15 @@ try:
 except ImportError:
     SQLAlchemySink = None  # type: ignore[misc, assignment]
 
+# DynamoDB sink is optional - import will fail if boto3 not installed
+try:
+    from bh_fastapi_audit.sinks.dynamodb import DynamoDBSink
+except ImportError:
+    DynamoDBSink = None  # type: ignore[misc, assignment]
+
 __all__ = [
     "AuditSink",
+    "DynamoDBSink",
     "JsonlFileSink",
     "LoggingSink",
     "MemorySink",

--- a/src/bh_fastapi_audit/sinks/dynamodb.py
+++ b/src/bh_fastapi_audit/sinks/dynamodb.py
@@ -1,0 +1,330 @@
+"""
+DynamoDB sink for audit events.
+
+Stores audit events in a single-table DynamoDB design optimized for
+healthcare compliance query patterns. Requires ``boto3`` (install via
+``pip install bh-fastapi-audit[dynamodb]``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TABLE_NAME = "bh_audit_events"
+_DEFAULT_TTL_DAYS = 2190  # ~6 years (HIPAA retention)
+_SECONDS_PER_DAY = 86_400
+
+
+def _iso_to_epoch(iso_ts: str) -> int:
+    """Convert an ISO 8601 UTC timestamp to Unix epoch seconds."""
+    cleaned = iso_ts.replace("Z", "+00:00")
+    from datetime import datetime
+
+    dt = datetime.fromisoformat(cleaned)
+    return int(dt.timestamp())
+
+
+class DynamoDBSink:
+    """Audit sink that writes events to DynamoDB.
+
+    Single-table design with three GSIs for compliance queries:
+
+    * **patient_id-index** — all access to a given patient
+    * **actor-index** — all actions by a given user
+    * **outcome-index** — all DENIED / FAILED outcomes
+
+    Args:
+        table_name: DynamoDB table name.
+        region: AWS region (default: from environment / boto3 default).
+        ttl_days: Days until TTL expiration (default: 2190 ≈ 6 years).
+                  Set to ``None`` to disable TTL.
+        create_table: If True, create the table on first use (dev/test only).
+
+    Example::
+
+        sink = DynamoDBSink(table_name="bh_audit_events", create_table=True)
+        sink.emit(event)
+    """
+
+    def __init__(
+        self,
+        table_name: str = _DEFAULT_TABLE_NAME,
+        region: str | None = None,
+        ttl_days: int | None = _DEFAULT_TTL_DAYS,
+        create_table: bool = False,
+    ) -> None:
+        self._table_name = table_name
+        self._ttl_days = ttl_days
+
+        kwargs: dict[str, Any] = {"service_name": "dynamodb"}
+        if region is not None:
+            kwargs["region_name"] = region
+        self._resource = boto3.resource(**kwargs)
+        self._table = self._resource.Table(table_name)
+
+        if create_table:
+            self._create_table()
+
+    # ------------------------------------------------------------------
+    # Emit
+    # ------------------------------------------------------------------
+
+    def emit(self, event: dict[str, Any]) -> None:
+        """Write an audit event to DynamoDB.
+
+        * Flattens key fields into top-level attributes for GSI queries.
+        * Stores full event JSON in ``event_json`` attribute.
+        * Sets TTL if configured.
+        * Uses condition expression on ``event_id`` to prevent overwrites.
+        """
+        item = self._flatten_event(event)
+
+        try:
+            self._table.put_item(
+                Item=item,
+                ConditionExpression="attribute_not_exists(event_id)",
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                logger.debug(
+                    "Duplicate event_id %s — skipping",
+                    event.get("event_id"),
+                )
+                return
+            raise
+
+    # ------------------------------------------------------------------
+    # GSI queries
+    # ------------------------------------------------------------------
+
+    def query_by_patient(
+        self,
+        patient_id: str,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Query GSI1 (patient_id-index) for patient access history."""
+        from boto3.dynamodb.conditions import Key
+
+        key_cond = Key("patient_id").eq(patient_id)
+        if start and end:
+            key_cond &= Key("timestamp").between(start, end)
+        elif start:
+            key_cond &= Key("timestamp").gte(start)
+        elif end:
+            key_cond &= Key("timestamp").lte(end)
+
+        resp = self._table.query(
+            IndexName="patient_id-index",
+            KeyConditionExpression=key_cond,
+        )
+        return resp.get("Items", [])
+
+    def query_by_actor(
+        self,
+        actor_id: str,
+        start: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Query GSI2 (actor-index) for user activity audit."""
+        from boto3.dynamodb.conditions import Key
+
+        key_cond = Key("actor_subject_id").eq(actor_id)
+        if start:
+            key_cond &= Key("timestamp").gte(start)
+
+        resp = self._table.query(
+            IndexName="actor-index",
+            KeyConditionExpression=key_cond,
+        )
+        return resp.get("Items", [])
+
+    def query_denials(
+        self,
+        start: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Query GSI3 (outcome-index) for all DENIED outcomes."""
+        from boto3.dynamodb.conditions import Key
+
+        key_cond = Key("outcome_status").eq("DENIED")
+        if start:
+            key_cond &= Key("timestamp").gte(start)
+
+        resp = self._table.query(
+            IndexName="outcome-index",
+            KeyConditionExpression=key_cond,
+        )
+        return resp.get("Items", [])
+
+    # ------------------------------------------------------------------
+    # Table creation (dev / test only)
+    # ------------------------------------------------------------------
+
+    def _create_table(self) -> None:
+        """Create the DynamoDB table with GSIs. Idempotent."""
+        try:
+            self._resource.create_table(
+                TableName=self._table_name,
+                KeySchema=[
+                    {"AttributeName": "service_date", "KeyType": "HASH"},
+                    {"AttributeName": "ts_event", "KeyType": "RANGE"},
+                ],
+                AttributeDefinitions=[
+                    {"AttributeName": "service_date", "AttributeType": "S"},
+                    {"AttributeName": "ts_event", "AttributeType": "S"},
+                    {"AttributeName": "patient_id", "AttributeType": "S"},
+                    {"AttributeName": "timestamp", "AttributeType": "S"},
+                    {"AttributeName": "actor_subject_id", "AttributeType": "S"},
+                    {"AttributeName": "outcome_status", "AttributeType": "S"},
+                ],
+                GlobalSecondaryIndexes=[
+                    {
+                        "IndexName": "patient_id-index",
+                        "KeySchema": [
+                            {"AttributeName": "patient_id", "KeyType": "HASH"},
+                            {"AttributeName": "timestamp", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {
+                            "ProjectionType": "INCLUDE",
+                            "NonKeyAttributes": [
+                                "event_id",
+                                "action_type",
+                                "actor_subject_id",
+                                "outcome_status",
+                                "data_classification",
+                                "http_route_template",
+                            ],
+                        },
+                        "ProvisionedThroughput": {
+                            "ReadCapacityUnits": 5,
+                            "WriteCapacityUnits": 5,
+                        },
+                    },
+                    {
+                        "IndexName": "actor-index",
+                        "KeySchema": [
+                            {"AttributeName": "actor_subject_id", "KeyType": "HASH"},
+                            {"AttributeName": "timestamp", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {
+                            "ProjectionType": "INCLUDE",
+                            "NonKeyAttributes": [
+                                "event_id",
+                                "action_type",
+                                "resource_type",
+                                "patient_id",
+                                "outcome_status",
+                                "http_route_template",
+                            ],
+                        },
+                        "ProvisionedThroughput": {
+                            "ReadCapacityUnits": 5,
+                            "WriteCapacityUnits": 5,
+                        },
+                    },
+                    {
+                        "IndexName": "outcome-index",
+                        "KeySchema": [
+                            {"AttributeName": "outcome_status", "KeyType": "HASH"},
+                            {"AttributeName": "timestamp", "KeyType": "RANGE"},
+                        ],
+                        "Projection": {
+                            "ProjectionType": "INCLUDE",
+                            "NonKeyAttributes": [
+                                "event_id",
+                                "actor_subject_id",
+                                "action_type",
+                                "resource_type",
+                                "patient_id",
+                                "error_type",
+                            ],
+                        },
+                        "ProvisionedThroughput": {
+                            "ReadCapacityUnits": 5,
+                            "WriteCapacityUnits": 5,
+                        },
+                    },
+                ],
+                BillingMode="PROVISIONED",
+                ProvisionedThroughput={
+                    "ReadCapacityUnits": 5,
+                    "WriteCapacityUnits": 5,
+                },
+            )
+            self._table.wait_until_exists()
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ResourceInUseException":
+                return
+            raise
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _flatten_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        """Extract top-level DynamoDB attributes from the nested event structure."""
+        service = event.get("service", {})
+        actor = event.get("actor", {})
+        action = event.get("action", {})
+        resource = event.get("resource", {})
+        outcome = event.get("outcome", {})
+        http = event.get("http", {})
+        integrity = event.get("integrity", {})
+
+        service_name = service.get("name", "unknown")
+        ts = event.get("timestamp", "")
+        date_part = ts[:10]
+        event_id = event.get("event_id", "")
+
+        item: dict[str, Any] = {
+            "service_date": f"{service_name}#{date_part}",
+            "ts_event": f"{ts}#{event_id}",
+            "event_id": event_id,
+            "timestamp": ts,
+            "service_name": service_name,
+            "environment": service.get("environment", "unknown"),
+            "actor_subject_id": actor.get("subject_id", "unknown"),
+            "actor_subject_type": actor.get("subject_type", "unknown"),
+            "action_type": action.get("type", "OTHER"),
+            "action_phi_touched": action.get("phi_touched", False),
+            "data_classification": action.get("data_classification", "UNKNOWN"),
+            "resource_type": resource.get("type", "Unknown"),
+            "outcome_status": outcome.get("status", "SUCCESS"),
+            "http_method": http.get("method"),
+            "http_route_template": http.get("route_template"),
+            "http_status_code": http.get("status_code"),
+            "event_json": json.dumps(event, separators=(",", ":"), ensure_ascii=False),
+        }
+
+        if resource.get("id"):
+            item["resource_id"] = resource["id"]
+        if resource.get("patient_id"):
+            item["patient_id"] = resource["patient_id"]
+        if actor.get("org_id"):
+            item["actor_org_id"] = actor["org_id"]
+        if actor.get("owner_org_id"):
+            item["actor_owner_org_id"] = actor["owner_org_id"]
+        if outcome.get("error_type"):
+            item["error_type"] = outcome["error_type"]
+
+        if integrity.get("event_hash"):
+            item["chain_hash"] = integrity["event_hash"]
+        if integrity.get("prev_event_hash"):
+            item["prev_chain_hash"] = integrity["prev_event_hash"]
+
+        if self._ttl_days is not None and ts:
+            item["ttl"] = _iso_to_epoch(ts) + (self._ttl_days * _SECONDS_PER_DAY)
+
+        # Remove None values — DynamoDB does not accept them
+        return {k: v for k, v in item.items() if v is not None}
+
+    @property
+    def table_name(self) -> str:
+        """Return the configured table name."""
+        return self._table_name

--- a/tests/test_dynamodb_sink.py
+++ b/tests/test_dynamodb_sink.py
@@ -1,0 +1,448 @@
+"""
+Tests for DynamoDBSink using moto to mock AWS DynamoDB.
+
+All tests run against a local mocked DynamoDB — no AWS credentials needed.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from bh_fastapi_audit.sinks.dynamodb import DynamoDBSink, _iso_to_epoch
+
+_REGION = "us-east-1"
+_TABLE = "bh_audit_events_test"
+
+
+def _make_event(**overrides: Any) -> dict[str, Any]:
+    """Return a minimal valid v1.1 audit event with optional overrides."""
+    event: dict[str, Any] = {
+        "schema_version": "1.1",
+        "event_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "service": {"name": "test-svc", "environment": "test"},
+        "actor": {"subject_id": "user-1", "subject_type": "human"},
+        "action": {"type": "READ", "data_classification": "PHI"},
+        "resource": {"type": "Patient", "patient_id": "pat_001"},
+        "outcome": {"status": "SUCCESS"},
+        "http": {
+            "method": "GET",
+            "route_template": "/patients/{patient_id}",
+            "status_code": 200,
+        },
+    }
+    event.update(overrides)
+    return event
+
+
+@pytest.fixture()
+def sink():
+    """Create a DynamoDBSink backed by moto."""
+    with mock_aws():
+        s = DynamoDBSink(
+            table_name=_TABLE,
+            region=_REGION,
+            create_table=True,
+        )
+        yield s
+
+
+@pytest.fixture()
+def ddb_table(sink):
+    """Return the underlying boto3 Table for direct inspection."""
+    return boto3.resource("dynamodb", region_name=_REGION).Table(_TABLE)
+
+
+# ------------------------------------------------------------------
+# Basic emit + retrieve
+# ------------------------------------------------------------------
+
+
+class TestEmit:
+    def test_emit_stores_event(self, sink, ddb_table):
+        event = _make_event()
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        assert resp["Count"] == 1
+        item = resp["Items"][0]
+        assert item["event_id"] == event["event_id"]
+
+    def test_emit_stores_event_json(self, sink, ddb_table):
+        event = _make_event()
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        roundtripped = json.loads(item["event_json"])
+        assert roundtripped["event_id"] == event["event_id"]
+        assert roundtripped["service"]["name"] == "test-svc"
+
+    def test_emit_multiple_events(self, sink, ddb_table):
+        for _ in range(5):
+            sink.emit(_make_event())
+
+        resp = ddb_table.scan()
+        assert resp["Count"] == 5
+
+
+# ------------------------------------------------------------------
+# PK / SK structure
+# ------------------------------------------------------------------
+
+
+class TestKeyStructure:
+    def test_pk_is_service_hash_date(self, sink, ddb_table):
+        event = _make_event(
+            timestamp="2026-04-15T14:32:07.123Z",
+            service={"name": "intake-api", "environment": "prod"},
+        )
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert item["service_date"] == "intake-api#2026-04-15"
+
+    def test_sk_is_timestamp_hash_event_id(self, sink, ddb_table):
+        eid = str(uuid.uuid4())
+        event = _make_event(
+            event_id=eid,
+            timestamp="2026-04-15T14:32:07.123Z",
+        )
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert item["ts_event"] == f"2026-04-15T14:32:07.123Z#{eid}"
+
+
+# ------------------------------------------------------------------
+# Conditional write (idempotency)
+# ------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_duplicate_event_id_is_ignored(self, sink, ddb_table):
+        event = _make_event()
+        sink.emit(event)
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        assert resp["Count"] == 1
+
+    def test_different_event_ids_both_stored(self, sink, ddb_table):
+        sink.emit(_make_event())
+        sink.emit(_make_event())
+
+        resp = ddb_table.scan()
+        assert resp["Count"] == 2
+
+
+# ------------------------------------------------------------------
+# GSI queries
+# ------------------------------------------------------------------
+
+
+class TestQueryByPatient:
+    def test_returns_events_for_patient(self, sink):
+        sink.emit(_make_event(resource={"type": "Patient", "patient_id": "pat_100"}))
+        sink.emit(_make_event(resource={"type": "Patient", "patient_id": "pat_200"}))
+        sink.emit(_make_event(resource={"type": "Patient", "patient_id": "pat_100"}))
+
+        results = sink.query_by_patient("pat_100")
+        assert len(results) == 2
+        assert all(r["patient_id"] == "pat_100" for r in results)
+
+    def test_returns_empty_for_unknown_patient(self, sink):
+        sink.emit(_make_event(resource={"type": "Patient", "patient_id": "pat_100"}))
+        results = sink.query_by_patient("pat_999")
+        assert results == []
+
+    def test_filters_by_time_range(self, sink):
+        sink.emit(
+            _make_event(
+                timestamp="2026-03-01T10:00:00.000Z",
+                resource={"type": "Patient", "patient_id": "pat_100"},
+            )
+        )
+        sink.emit(
+            _make_event(
+                timestamp="2026-04-15T10:00:00.000Z",
+                resource={"type": "Patient", "patient_id": "pat_100"},
+            )
+        )
+
+        results = sink.query_by_patient("pat_100", start="2026-04-01", end="2026-04-30")
+        assert len(results) == 1
+        assert results[0]["timestamp"] == "2026-04-15T10:00:00.000Z"
+
+    def test_filters_with_start_only(self, sink):
+        sink.emit(
+            _make_event(
+                timestamp="2026-01-01T00:00:00.000Z",
+                resource={"type": "Patient", "patient_id": "pat_100"},
+            )
+        )
+        sink.emit(
+            _make_event(
+                timestamp="2026-06-01T00:00:00.000Z",
+                resource={"type": "Patient", "patient_id": "pat_100"},
+            )
+        )
+
+        results = sink.query_by_patient("pat_100", start="2026-05-01")
+        assert len(results) == 1
+
+
+class TestQueryByActor:
+    def test_returns_events_for_actor(self, sink):
+        sink.emit(_make_event(actor={"subject_id": "user-A", "subject_type": "human"}))
+        sink.emit(_make_event(actor={"subject_id": "user-B", "subject_type": "human"}))
+        sink.emit(_make_event(actor={"subject_id": "user-A", "subject_type": "human"}))
+
+        results = sink.query_by_actor("user-A")
+        assert len(results) == 2
+
+    def test_filters_by_start(self, sink):
+        sink.emit(
+            _make_event(
+                timestamp="2026-01-01T00:00:00.000Z",
+                actor={"subject_id": "user-A", "subject_type": "human"},
+            )
+        )
+        sink.emit(
+            _make_event(
+                timestamp="2026-06-01T00:00:00.000Z",
+                actor={"subject_id": "user-A", "subject_type": "human"},
+            )
+        )
+
+        results = sink.query_by_actor("user-A", start="2026-05-01")
+        assert len(results) == 1
+
+
+class TestQueryDenials:
+    def test_returns_denied_events(self, sink):
+        sink.emit(_make_event(outcome={"status": "DENIED", "error_type": "RoleDenied"}))
+        sink.emit(_make_event(outcome={"status": "SUCCESS"}))
+        sink.emit(_make_event(outcome={"status": "DENIED", "error_type": "ConsentRequired"}))
+
+        results = sink.query_denials()
+        assert len(results) == 2
+        assert all(r["outcome_status"] == "DENIED" for r in results)
+
+    def test_filters_by_start(self, sink):
+        sink.emit(
+            _make_event(
+                timestamp="2026-01-01T00:00:00.000Z",
+                outcome={"status": "DENIED", "error_type": "RoleDenied"},
+            )
+        )
+        sink.emit(
+            _make_event(
+                timestamp="2026-06-01T00:00:00.000Z",
+                outcome={"status": "DENIED", "error_type": "RoleDenied"},
+            )
+        )
+
+        results = sink.query_denials(start="2026-05-01")
+        assert len(results) == 1
+
+
+# ------------------------------------------------------------------
+# TTL
+# ------------------------------------------------------------------
+
+
+class TestTTL:
+    def test_ttl_calculated_correctly(self, sink, ddb_table):
+        ts = "2026-04-15T12:00:00.000Z"
+        event = _make_event(timestamp=ts)
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        expected_ttl = _iso_to_epoch(ts) + (2190 * 86_400)
+        assert int(item["ttl"]) == expected_ttl
+
+    def test_ttl_disabled_when_none(self):
+        with mock_aws():
+            sink = DynamoDBSink(
+                table_name=_TABLE,
+                region=_REGION,
+                ttl_days=None,
+                create_table=True,
+            )
+            event = _make_event()
+            sink.emit(event)
+
+            table = boto3.resource("dynamodb", region_name=_REGION).Table(_TABLE)
+            resp = table.scan()
+            item = resp["Items"][0]
+            assert "ttl" not in item
+
+
+# ------------------------------------------------------------------
+# Flattening
+# ------------------------------------------------------------------
+
+
+class TestFlatten:
+    def test_flattens_core_fields(self, sink, ddb_table):
+        event = _make_event(
+            actor={"subject_id": "dr-smith", "subject_type": "human"},
+            action={"type": "CREATE", "data_classification": "PHI"},
+            resource={"type": "Encounter", "patient_id": "pat_42"},
+            outcome={"status": "SUCCESS"},
+        )
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert item["actor_subject_id"] == "dr-smith"
+        assert item["action_type"] == "CREATE"
+        assert item["data_classification"] == "PHI"
+        assert item["resource_type"] == "Encounter"
+        assert item["patient_id"] == "pat_42"
+        assert item["outcome_status"] == "SUCCESS"
+
+    def test_optional_fields_omitted_when_absent(self, sink, ddb_table):
+        event = _make_event(resource={"type": "Config"})
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert "patient_id" not in item
+        assert "resource_id" not in item
+        assert "actor_org_id" not in item
+
+    def test_error_type_included_for_failures(self, sink, ddb_table):
+        event = _make_event(
+            outcome={"status": "FAILURE", "error_type": "HTTP500", "error_message": "fail"},
+        )
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert item["error_type"] == "HTTP500"
+
+    def test_integrity_fields_flattened(self, sink, ddb_table):
+        event = _make_event(
+            integrity={
+                "event_hash": "abc123",
+                "prev_event_hash": "xyz789",
+                "hash_alg": "sha256",
+            }
+        )
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert item["chain_hash"] == "abc123"
+        assert item["prev_chain_hash"] == "xyz789"
+
+    def test_v10_event_flattens_correctly(self, sink, ddb_table):
+        event = _make_event(
+            schema_version="1.0",
+            outcome={"status": "FAILURE", "error_type": "HTTP403", "error_message": "denied"},
+        )
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert item["outcome_status"] == "FAILURE"
+        assert item["error_type"] == "HTTP403"
+
+    def test_http_fields_flattened(self, sink, ddb_table):
+        event = _make_event(
+            http={
+                "method": "POST",
+                "route_template": "/patients",
+                "status_code": 201,
+            }
+        )
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert item["http_method"] == "POST"
+        assert item["http_route_template"] == "/patients"
+        assert int(item["http_status_code"]) == 201
+
+
+# ------------------------------------------------------------------
+# Table creation
+# ------------------------------------------------------------------
+
+
+class TestCreateTable:
+    def test_create_table_is_idempotent(self):
+        with mock_aws():
+            DynamoDBSink(table_name=_TABLE, region=_REGION, create_table=True)
+            DynamoDBSink(table_name=_TABLE, region=_REGION, create_table=True)
+
+            client = boto3.client("dynamodb", region_name=_REGION)
+            tables = client.list_tables()["TableNames"]
+            assert tables.count(_TABLE) == 1
+
+    def test_table_has_correct_gsis(self):
+        with mock_aws():
+            DynamoDBSink(table_name=_TABLE, region=_REGION, create_table=True)
+
+            client = boto3.client("dynamodb", region_name=_REGION)
+            desc = client.describe_table(TableName=_TABLE)["Table"]
+            gsi_names = {g["IndexName"] for g in desc.get("GlobalSecondaryIndexes", [])}
+            assert gsi_names == {"patient_id-index", "actor-index", "outcome-index"}
+
+
+# ------------------------------------------------------------------
+# event_json round-trip
+# ------------------------------------------------------------------
+
+
+class TestEventJsonRoundTrip:
+    def test_full_event_recoverable(self, sink, ddb_table):
+        event = _make_event(
+            correlation={"request_id": "req-123", "trace_id": "trace-456"},
+            metadata={"department": "cardiology"},
+        )
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        recovered = json.loads(item["event_json"])
+        assert recovered == event
+
+
+# ------------------------------------------------------------------
+# Edge cases
+# ------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_missing_service_name_uses_unknown(self, sink, ddb_table):
+        event = _make_event()
+        event["service"] = {}
+        sink.emit(event)
+
+        resp = ddb_table.scan()
+        item = resp["Items"][0]
+        assert item["service_date"].startswith("unknown#")
+
+    def test_empty_timestamp_raises(self, sink):
+        """DynamoDB rejects empty strings on GSI key attributes."""
+        from botocore.exceptions import ClientError
+
+        event = _make_event(timestamp="")
+        with pytest.raises(ClientError):
+            sink.emit(event)
+
+    def test_table_name_property(self, sink):
+        assert sink.table_name == _TABLE

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -81,6 +81,19 @@ def test_sqlalchemy_sink_import():
         assert SQLAlchemySink is None
 
 
+def test_dynamodb_sink_import():
+    """DynamoDBSink should be importable (may be None if boto3 not installed)."""
+    from bh_fastapi_audit import DynamoDBSink
+
+    try:
+        import boto3  # noqa: F401
+
+        assert DynamoDBSink is not None
+        assert hasattr(DynamoDBSink, "emit")
+    except ImportError:
+        assert DynamoDBSink is None
+
+
 def test_version_exposed():
     """Package version should be accessible."""
     from bh_fastapi_audit import __version__
@@ -115,6 +128,7 @@ def test_all_exports_defined():
         "ServiceBlock",
         # Sinks
         "AuditSink",
+        "DynamoDBSink",
         "JsonlFileSink",
         "LoggingSink",
         "MemorySink",


### PR DESCRIPTION

- **`DynamoDBSink`** — production-grade audit sink for AWS DynamoDB (`pip install
  bh-fastapi-audit[dynamodb]`).  Single-table design with `service#date` partition
  key and `timestamp#event_id` sort key, optimized for time-range queries per service.
  - Three Global Secondary Indexes for compliance queries:
    - `patient_id-index` — all access to a given patient (HIPAA §164.312(b))
    - `actor-index` — all actions by a given user (HIPAA §164.308(a)(1)(ii)(D))
    - `outcome-index` — all DENIED/FAILED outcomes (HIPAA §164.308(a)(5)(ii)(C))
  - `query_by_patient()`, `query_by_actor()`, `query_denials()` convenience methods
    with optional time-range filtering.
  - TTL-based retention (default 2190 days ≈ 6 years for HIPAA), disable with
    `ttl_days=None`.
  - Conditional PutItem on `event_id` prevents duplicate writes (idempotent).
  - Full event stored as compact JSON in `event_json` attribute for archival/replay.
  - Key fields (actor, action, resource, outcome, HTTP) flattened to top-level
    DynamoDB attributes for GSI projections.
  - `create_table=True` convenience flag for dev/test (creates table + GSIs).
  - `boto3` is an **optional dependency** — guarded import, same pattern as
    `SQLAlchemySink`.
- **`[dynamodb]` optional extra** — `pip install bh-fastapi-audit[dynamodb]` installs
  `boto3>=1.34,<2`.
- **`moto[dynamodb]`** added to `[dev]` extras for DynamoDB test mocking.