### PR TITLE
verifier cli, opt-in-telemetry, chain hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-04-02
 
 ### Added
 
+- **Verifier CLI** — `bh-audit verify` command for chain integrity verification.
+  Supports `--source file` (JSONL) and `--source dynamodb` (DynamoDB table query),
+  with `--format human` (default) and `--format json` (CI pipelines).
+  Exit codes: 0 = PASS, 1 = FAIL, 2 = ERROR.
+  Install with `pip install bh-fastapi-audit[cli]`.
+- **Programmatic verifier** — `verify_chain()`, `VerifyResult`, `VerifyFailure`
+  exported from top-level package for programmatic chain verification.
+- **Opt-in telemetry** — privacy-first, counter-based weekly usage reports.
+  No PII, no PHI, no event content. Off by default (`telemetry_enabled=False`).
+  See `docs/telemetry.md`.
+- **`[cli]` optional extra** — `typer>=0.9,<1` for the verifier CLI.
+- **Documentation**: `docs/telemetry.md`, `docs/threat-model.md`,
+  `docs/storage-patterns.md`.
 - **`EmitFailureMode`** type alias exported from `bh_fastapi_audit` — `Literal["silent", "log", "raise"]`.
 - **`HashAlgorithm`** and **`IntegrityBlock`** type aliases now exported from
   the top-level package for downstream type checking.
@@ -344,7 +357,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apache 2.0 license
 - Vendored bh-audit-schema v1.0 JSON schema
 
-[Unreleased]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.4.0...HEAD
+[0.5.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.2.1...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 2026-04-02
+## [1.0.0] - 2026-04-04
 
 ### Added
 
@@ -357,7 +357,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apache 2.0 license
 - Vendored bh-audit-schema v1.0 JSON schema
 
-[0.5.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.4.0...v0.5.0
+[1.0.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.2.1...v0.2.2

--- a/README.md
+++ b/README.md
@@ -15,9 +15,17 @@ The goal of this library is to make consistent, structured audit trails easy to 
 
 This project is an implementation layer that turns the bh-audit-schema standard into working FastAPI middleware.
 
-**Current version: v0.4.0** — Runtime validation, DENIED outcome with denial callbacks, schema negotiation (v1.0/v1.1), vendored dual-schema support.
+**Current version: v0.5.0** — Verifier CLI, opt-in telemetry, chain hashing, DynamoDB sink, runtime validation, DENIED outcome with denial callbacks, schema negotiation.
 
-### v0.4 (current)
+### v0.5 (current)
+- **Verifier CLI** — `bh-audit verify` for chain integrity verification (file or DynamoDB source, human or JSON output)
+- **Programmatic verifier** — `verify_chain()`, `VerifyResult`, `VerifyFailure` for code-level chain verification
+- **Opt-in telemetry** — privacy-first, counter-based weekly aggregate reports (no PII/PHI)
+- **Chain hashing** — tamper-evident audit trails via SHA-256 chain hashing with `enable_integrity=True`
+- **DynamoDB sink** — production-grade DynamoDB sink with 3 GSIs for HIPAA compliance queries
+- **LedgerSink** — JSONL file sink with built-in chain hashing
+
+### v0.4
 - **Runtime event validation** — optional `validate_events=True` checks every event against the vendored JSON schema before emission, with configurable failure modes (`drop`, `log_and_emit`, `raise`)
 - **DENIED outcome with denial callback** — `get_denial_reason` callback provides rich denial categories (e.g. `RoleDenied`, `ConsentRequired`, `CrossOrgAccessDenied`) for compliance queries
 - **Configurable denied status codes** — `denied_status_codes` config (default `{401, 403}`)
@@ -307,21 +315,84 @@ This library is designed to be safe by default:
 
 PHI safety is enforced by tests that assert synthetic PHI tokens never appear in emitted events.
 
+## Chain hashing (integrity)
+
+v0.5 adds tamper-evident audit trails via SHA-256 chain hashing:
+
+```python
+from bh_fastapi_audit import ChainState
+
+config = AuditConfig(
+    service_name="my-api",
+    enable_integrity=True,
+    chain_state=ChainState(),
+    hash_algorithm="sha256",
+)
+```
+
+For DynamoDB-backed multi-process chain state:
+
+```python
+from bh_fastapi_audit import DynamoDBChainState
+
+chain_state = DynamoDBChainState(table_name="bh_chain_state", service_name="my-api")
+config = AuditConfig(
+    service_name="my-api",
+    enable_integrity=True,
+    chain_state=chain_state,
+)
+```
+
+## Verifier CLI
+
+v0.5 adds `bh-audit verify` for chain integrity verification:
+
+```bash
+pip install bh-fastapi-audit[cli]
+
+# Verify a JSONL ledger file
+bh-audit verify --source file --path /var/log/audit/events.jsonl
+
+# Verify from DynamoDB
+bh-audit verify --source dynamodb --table bh_audit_events --service my-api
+
+# JSON output for CI pipelines
+bh-audit verify --source file --path events.jsonl --format json
+```
+
+Programmatic verification:
+
+```python
+from bh_fastapi_audit import verify_chain
+
+result = verify_chain(events)
+assert result.result == "PASS"
+```
+
+## Telemetry
+
+v0.5 adds opt-in, privacy-first telemetry. **Off by default.** No PII, no PHI, no event content -- only aggregate counters.
+
+```python
+config = AuditConfig(
+    service_name="my-api",
+    telemetry_enabled=True,  # explicit opt-in required
+)
+```
+
+See [docs/telemetry.md](docs/telemetry.md) for the full privacy commitment and payload format.
+
 ## Installation
 
 **Requires Python 3.11+**
 
 ```bash
-pip install bh-fastapi-audit
+pip install bh-fastapi-audit                # core (FastAPI + Pydantic)
+pip install bh-fastapi-audit[dynamodb]      # + DynamoDB sink (boto3)
+pip install bh-fastapi-audit[cli]           # + bh-audit verify CLI (typer)
+pip install bh-fastapi-audit[sqlalchemy]    # + SQLAlchemy sink
+pip install bh-fastapi-audit[jsonschema]    # + runtime schema validation
 ```
-
-### Optional dependencies
-
-```bash
-pip install bh-fastapi-audit[sqlalchemy]    # Database sink
-```
-
-> **Note:** `jsonschema` is a required dependency as of v0.4.0 (runtime validation support).
 
 ### Development installation
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The goal of this library is to make consistent, structured audit trails easy to 
 
 This project is an implementation layer that turns the bh-audit-schema standard into working FastAPI middleware.
 
-**Current version: v0.5.0** — Verifier CLI, opt-in telemetry, chain hashing, DynamoDB sink, runtime validation, DENIED outcome with denial callbacks, schema negotiation.
+**Current version: v1.0.0** — Verifier CLI, opt-in telemetry, chain hashing, DynamoDB sink, runtime validation, DENIED outcome with denial callbacks, schema negotiation.
 
-### v0.5 (current)
+### v1.0 (current)
 - **Verifier CLI** — `bh-audit verify` for chain integrity verification (file or DynamoDB source, human or JSON output)
 - **Programmatic verifier** — `verify_chain()`, `VerifyResult`, `VerifyFailure` for code-level chain verification
 - **Opt-in telemetry** — privacy-first, counter-based weekly aggregate reports (no PII/PHI)
@@ -303,6 +303,12 @@ See [docs/migrating-1.0-to-1.1.md](docs/migrating-1.0-to-1.1.md) for a full migr
 | `get_denial_reason` | `None` | Callback `(Request, exc_info) -> str\|None` for denial categorization |
 | `denied_status_codes` | `frozenset({401, 403})` | Status codes that produce DENIED outcome |
 | `target_schema_version` | `"1.1"` | Schema version for emitted events (`"1.0"` or `"1.1"`) |
+| `enable_integrity` | `False` | Enable chain hashing on emitted events |
+| `chain_state` | `None` | Chain state backend (`ChainState` or `DynamoDBChainState`) |
+| `hash_algorithm` | `"sha256"` | Hash algorithm for chain hashing (`"sha256"`, `"sha384"`, `"sha512"`) |
+| `telemetry_enabled` | `False` | Enable opt-in anonymous telemetry |
+| `telemetry_endpoint` | `"https://…/v1/report"` | Telemetry receiver URL |
+| `telemetry_deployment_id_path` | `"/tmp/bh-audit/"` | Directory for anonymous deployment ID file |
 
 ## PHI-safe defaults
 
@@ -317,7 +323,7 @@ PHI safety is enforced by tests that assert synthetic PHI tokens never appear in
 
 ## Chain hashing (integrity)
 
-v0.5 adds tamper-evident audit trails via SHA-256 chain hashing:
+v1.0 adds tamper-evident audit trails via SHA-256 chain hashing:
 
 ```python
 from bh_fastapi_audit import ChainState
@@ -345,7 +351,7 @@ config = AuditConfig(
 
 ## Verifier CLI
 
-v0.5 adds `bh-audit verify` for chain integrity verification:
+v1.0 adds `bh-audit verify` for chain integrity verification:
 
 ```bash
 pip install bh-fastapi-audit[cli]
@@ -371,7 +377,7 @@ assert result.result == "PASS"
 
 ## Telemetry
 
-v0.5 adds opt-in, privacy-first telemetry. **Off by default.** No PII, no PHI, no event content -- only aggregate counters.
+v1.0 adds opt-in, privacy-first telemetry. **Off by default.** No PII, no PHI, no event content -- only aggregate counters.
 
 ```python
 config = AuditConfig(

--- a/docs/storage-patterns.md
+++ b/docs/storage-patterns.md
@@ -6,26 +6,36 @@ Recommended storage layouts and query patterns for bh-fastapi-audit sinks.
 
 ### Primary table: `bh_audit_events`
 
-| Attribute       | Type   | Role              |
-|-----------------|--------|-------------------|
-| `pk`            | String | Partition key     |
-| `sk`            | String | Sort key          |
-| `event_id`      | String | Unique event UUID |
-| `event_json`    | String | Serialised event  |
-| `actor_id`      | String | GSI partition key  |
-| `ttl`           | Number | TTL epoch (optional) |
+| Attribute          | Type   | Role                       |
+|--------------------|--------|----------------------------|
+| `service_date`     | String | Partition key (`<service>#<date>`) |
+| `ts_event`         | String | Sort key (`<ISO timestamp>#<event_id>`) |
+| `event_id`         | String | Unique event UUID          |
+| `timestamp`        | String | ISO 8601 UTC               |
+| `service_name`     | String | e.g. `"intake-api"`        |
+| `actor_subject_id` | String | Who performed the action   |
+| `patient_id`       | String | Nullable, for GSI1         |
+| `outcome_status`   | String | SUCCESS / FAILURE / DENIED |
+| `event_json`       | String | Full event as compact JSON |
+| `chain_hash`       | String | SHA-256 of this event      |
+| `prev_chain_hash`  | String | SHA-256 of previous event  |
+| `ttl`              | Number | TTL epoch (optional)       |
 
-**PK/SK rationale**: `pk = SERVICE#<service_name>`, `sk = <ISO timestamp>#<event_id>`.
-This gives per-service partitioning with time-ordered sort keys for efficient range queries.
+**PK/SK rationale**: `service_date = <service_name>#<YYYY-MM-DD>`,
+`ts_event = <ISO timestamp>#<event_id>`. This gives per-service daily
+partitioning with time-ordered sort keys for efficient range queries.
 
 ### Global Secondary Indexes
 
-| GSI Name         | PK           | SK              | Projection |
-|------------------|--------------|-----------------|------------|
-| `actor-index`    | `actor_id`   | `sk` (timestamp)| ALL        |
+| GSI Name           | PK                 | SK          | Projection | Use case |
+|--------------------|--------------------|-------------|------------|----------|
+| `patient_id-index` | `patient_id`       | `timestamp` | INCLUDE    | All access to patient X (HIPAA §164.312(b)) |
+| `actor-index`      | `actor_subject_id` | `timestamp` | INCLUDE    | All actions by user Y (§164.308(a)(1)(ii)(D)) |
+| `outcome-index`    | `outcome_status`   | `timestamp` | INCLUDE    | All DENIED / FAILED outcomes |
 
-The actor GSI enables "show me all events for user X" queries required by
-HIPAA accounting-of-disclosures.
+Each GSI projects key attributes needed for compliance queries (event_id,
+action_type, actor_subject_id, outcome_status, etc.) plus `event_json`
+on patient and actor indexes.
 
 ### Billing mode
 
@@ -37,8 +47,8 @@ is harder to size correctly and risks throttling during peak audit volume.
 
 - Average event size: ~1-2 KB (JSON)
 - Write throughput: one WCU per event (< 1 KB) or two WCUs (1-2 KB)
-- Read throughput: `bh-audit verify` performs a full table scan; consider
-  scheduling during off-peak hours
+- Read throughput: `bh-audit verify` performs a GSI query against the
+  `actor-index`; consider scheduling during off-peak hours for large result sets
 
 ## JSONL File Layout (LedgerSink)
 
@@ -124,8 +134,10 @@ event_item["ttl"] = int(time.time()) + (TTL_DAYS * 86400)
 
 | Scenario                          | Source   | Query                                    |
 |-----------------------------------|----------|------------------------------------------|
-| All events for a patient          | DynamoDB | GSI `actor-index`, PK = patient_id       |
-| Events in a time window           | DynamoDB | Query PK = service, SK between timestamps |
+| All events for a patient          | DynamoDB | GSI `patient_id-index`, PK = patient_id  |
+| All actions by a user             | DynamoDB | GSI `actor-index`, PK = actor_subject_id |
+| All DENIED outcomes               | DynamoDB | GSI `outcome-index`, PK = `"DENIED"`     |
+| Events in a time window           | DynamoDB | Query PK = `<service>#<date>`, SK between timestamps |
 | Full chain verification           | File     | `bh-audit verify --source file --path …` |
-| Full chain verification           | DynamoDB | `bh-audit verify --source dynamodb --table …` |
-| Compliance audit (accounting of disclosures) | DynamoDB | GSI query + filter on action.type = READ |
+| Full chain verification           | DynamoDB | `bh-audit verify --source dynamodb --table … --service …` |
+| Accounting of disclosures (HIPAA) | DynamoDB | GSI `patient_id-index` + filter on action_type = READ |

--- a/docs/storage-patterns.md
+++ b/docs/storage-patterns.md
@@ -1,0 +1,131 @@
+# Storage Patterns
+
+Recommended storage layouts and query patterns for bh-fastapi-audit sinks.
+
+## DynamoDB Table Design
+
+### Primary table: `bh_audit_events`
+
+| Attribute       | Type   | Role              |
+|-----------------|--------|-------------------|
+| `pk`            | String | Partition key     |
+| `sk`            | String | Sort key          |
+| `event_id`      | String | Unique event UUID |
+| `event_json`    | String | Serialised event  |
+| `actor_id`      | String | GSI partition key  |
+| `ttl`           | Number | TTL epoch (optional) |
+
+**PK/SK rationale**: `pk = SERVICE#<service_name>`, `sk = <ISO timestamp>#<event_id>`.
+This gives per-service partitioning with time-ordered sort keys for efficient range queries.
+
+### Global Secondary Indexes
+
+| GSI Name         | PK           | SK              | Projection |
+|------------------|--------------|-----------------|------------|
+| `actor-index`    | `actor_id`   | `sk` (timestamp)| ALL        |
+
+The actor GSI enables "show me all events for user X" queries required by
+HIPAA accounting-of-disclosures.
+
+### Billing mode
+
+`PAY_PER_REQUEST` (on-demand) is recommended for audit workloads, which tend
+to be spiky around business hours and near-zero overnight. Provisioned capacity
+is harder to size correctly and risks throttling during peak audit volume.
+
+### Capacity considerations
+
+- Average event size: ~1-2 KB (JSON)
+- Write throughput: one WCU per event (< 1 KB) or two WCUs (1-2 KB)
+- Read throughput: `bh-audit verify` performs a full table scan; consider
+  scheduling during off-peak hours
+
+## JSONL File Layout (LedgerSink)
+
+```
+/var/log/audit/
+├── events.jsonl          # Active ledger file
+├── events.2026-03-29.jsonl  # Rotated daily
+└── events.2026-03-22.jsonl
+```
+
+Each line is a complete JSON event. The `LedgerSink` automatically computes
+chain hashes as events are appended. File rotation is left to the operator
+(logrotate, cron, etc.).
+
+### Verification
+
+```bash
+bh-audit verify --source file --path /var/log/audit/events.jsonl
+```
+
+For rotated files, concatenate in chronological order:
+
+```bash
+cat events.2026-03-22.jsonl events.2026-03-29.jsonl events.jsonl | \
+    bh-audit verify --source file --path /dev/stdin
+```
+
+## S3 Archive Layout (Future)
+
+For long-term immutable retention:
+
+```
+s3://bh-audit-archive/
+├── service=intake-api/
+│   ├── year=2026/
+│   │   ├── month=03/
+│   │   │   ├── day=29/
+│   │   │   │   └── events-20260329T000000-20260329T235959.jsonl.gz
+│   │   │   └── day=30/
+│   │   │       └── events-20260330T000000-20260330T235959.jsonl.gz
+```
+
+### Recommended S3 settings
+
+- **Object Lock**: Governance or Compliance mode with retention matching
+  your regulatory requirement (HIPAA: 6 years, 42 CFR Part 2: 6 years)
+- **Storage class**: S3 Glacier Instant Retrieval for archives > 90 days
+- **Lifecycle rules**: Transition to Glacier after 90 days, expire after
+  retention period
+
+## Retention Automation
+
+### DynamoDB TTL
+
+Set a `ttl` attribute on each item (epoch seconds). DynamoDB automatically
+deletes expired items within ~48 hours. Suitable for operational retention
+(e.g. 90 days) when events are also archived to S3.
+
+```python
+import time
+TTL_DAYS = 90
+event_item["ttl"] = int(time.time()) + (TTL_DAYS * 86400)
+```
+
+### S3 Lifecycle
+
+```json
+{
+  "Rules": [
+    {
+      "ID": "audit-archive-lifecycle",
+      "Status": "Enabled",
+      "Transitions": [
+        {"Days": 90, "StorageClass": "GLACIER_IR"}
+      ],
+      "Expiration": {"Days": 2190}
+    }
+  ]
+}
+```
+
+## Common Query Patterns
+
+| Scenario                          | Source   | Query                                    |
+|-----------------------------------|----------|------------------------------------------|
+| All events for a patient          | DynamoDB | GSI `actor-index`, PK = patient_id       |
+| Events in a time window           | DynamoDB | Query PK = service, SK between timestamps |
+| Full chain verification           | File     | `bh-audit verify --source file --path …` |
+| Full chain verification           | DynamoDB | `bh-audit verify --source dynamodb --table …` |
+| Compliance audit (accounting of disclosures) | DynamoDB | GSI query + filter on action.type = READ |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,86 @@
+# Telemetry
+
+bh-fastapi-audit includes an **opt-in, privacy-first** telemetry system that reports
+aggregate usage statistics to help the maintainers understand how the library is used
+in the wild and prioritise improvements.
+
+## Off by default
+
+Telemetry is **disabled** unless you explicitly enable it:
+
+```python
+config = AuditConfig(
+    service_name="intake-api",
+    telemetry_enabled=True,               # opt-in
+    telemetry_endpoint="https://abt0rxi196.execute-api.us-east-1.amazonaws.com/v1/report",
+    telemetry_deployment_id_path="/tmp/bh-audit/",
+)
+```
+
+## What is sent
+
+A single JSON report per deployment, per week (Sunday-to-Sunday):
+
+```json
+{
+  "schema_version": "1.0",
+  "deployment_id": "a1b2c3d4-...",
+  "service_name": "intake-api",
+  "environment": "production",
+  "package": "bh-fastapi-audit",
+  "package_version": "0.5.0",
+  "period_start": "2026-03-29T00:00:00+00:00",
+  "period_end": "2026-04-05T00:00:00+00:00",
+  "counters": {
+    "events_emitted": 12847,
+    "by_action_type": {"READ": 8021, "CREATE": 3102, "UPDATE": 1724},
+    "by_outcome": {"SUCCESS": 12500, "FAILURE": 347},
+    "by_data_classification": {"PHI": 9000, "RESTRICTED": 3847},
+    "integrity_events": 12847,
+    "chain_gaps": 0,
+    "emit_failures": 2
+  }
+}
+```
+
+## What is NOT sent
+
+- No event content, payloads, or field values
+- No patient identifiers, actor IDs, or session tokens
+- No IP addresses, hostnames, or network information
+- No request/response bodies or headers
+- No file paths, database connection strings, or credentials
+- No error messages or stack traces
+
+## How it works
+
+1. On each request, after the audit event is emitted, counters are incremented
+   in-memory (thread-safe).
+2. On each call, the current UTC time is compared to the period boundary.
+3. When the period boundary is crossed, the report is POSTed via `urllib.request`
+   with a 5-second timeout.
+4. Counters are reset after successful emission.
+5. **No background threads** -- this works in Lambda and single-process environments.
+
+## Deployment ID
+
+An anonymous UUID is generated on first run and persisted to
+`<telemetry_deployment_id_path>/.bh-audit-deployment-id`. This allows correlating
+weekly reports from the same deployment without identifying the operator.
+
+## Failure behaviour
+
+If the HTTP POST fails (network error, timeout, non-200 response), the failure is
+silently swallowed. A `DEBUG`-level log message is emitted to the `bh.audit.telemetry`
+logger. Counters are **not** reset on failure, so the data rolls into the next period.
+
+Telemetry never raises exceptions and never affects application behaviour.
+
+## Disabling telemetry
+
+Set `telemetry_enabled=False` (the default) or simply omit the setting:
+
+```python
+config = AuditConfig(service_name="my-service")
+# telemetry_enabled defaults to False -- nothing is sent
+```

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -28,7 +28,7 @@ A single JSON report per deployment, per week (Sunday-to-Sunday):
   "service_name": "intake-api",
   "environment": "production",
   "package": "bh-fastapi-audit",
-  "package_version": "0.5.0",
+  "package_version": "1.0.0",
   "period_start": "2026-03-29T00:00:00+00:00",
   "period_end": "2026-04-05T00:00:00+00:00",
   "counters": {

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,115 @@
+# Threat Model
+
+This document describes the security boundaries and threat posture of the
+bh-fastapi-audit chain hashing and verification system.
+
+## What the system protects against
+
+### Event tampering (post-emission)
+
+Each event's content is hashed via SHA-256 (or SHA-384/512). If any field is
+modified after emission, `bh-audit verify` detects the mismatch.
+
+**Mitigation**: `compute_chain_hash` produces a deterministic hash over the
+canonical serialization of the event (sorted keys, compact JSON, UTF-8).
+Verification recomputes and compares.
+
+### Silent deletion
+
+Each event's hash includes the previous event's hash (`prev_event_hash`),
+forming a hash chain. Deleting an event mid-chain causes a chain gap that
+`verify_chain` detects.
+
+**Mitigation**: The `prev_event_hash` field links events together. Any break
+in the chain is flagged as a `chain_gap` failure.
+
+### Event reordering / replay
+
+Reordering events breaks `prev_event_hash` linkage. Replaying an event with
+a correct hash but wrong position in the chain is detected as a gap.
+
+**Mitigation**: Ordered verification with `verify_chain()` ensures events
+are in the expected sequence.
+
+## What the system does NOT protect against
+
+### Compromised event producer
+
+If the service emitting events is compromised, the attacker can emit
+well-formed, correctly-hashed fraudulent events. Chain hashing verifies
+integrity, not authenticity.
+
+**Accept**: This is a fundamental limitation of symmetric hashing. For
+producer authentication, consider asymmetric signing (future work).
+
+### Root / admin access to storage
+
+An attacker with write access to the DynamoDB table or JSONL file can
+rewrite the entire chain with valid hashes. The system cannot detect a
+complete chain replacement.
+
+**Mitigate**: Use DynamoDB point-in-time recovery, S3 Object Lock, or
+immutable storage for the audit trail. Cross-reference with external
+systems (SIEM, CloudTrail).
+
+### Clock manipulation
+
+Timestamps are taken from the application host. If the clock is skewed or
+manipulated, events may appear out of order but the hash chain remains valid.
+
+**Mitigate**: Use NTP-synchronized hosts. Monitor for timestamp anomalies
+in compliance reviews.
+
+### Side-channel attacks
+
+The hashing implementation uses Python's `hashlib` which does not provide
+constant-time comparison. This is acceptable because audit hashes are not
+secrets -- they are stored alongside the events.
+
+## Trust boundaries
+
+```
+┌──────────────────────────────────────┐
+│  FastAPI Application Process         │
+│  ┌─────────────────┐ ┌───────────┐  │
+│  │ AuditMiddleware  │ │ChainState │  │
+│  │ (ASGI, producer) │ │(in-memory │  │
+│  └───────┬─────────┘ │or DynamoDB)│  │
+│          │            └───────────┘  │
+│          ▼                           │
+│  ┌──────────┐                        │
+│  │ Sink     │  (LoggingSink,         │
+│  │          │   DynamoDBSink,        │
+│  │          │   LedgerSink, etc.)    │
+│  └─────┬────┘                        │
+└────────┼─────────────────────────────┘
+         │  TRUST BOUNDARY
+         ▼
+┌──────────────────┐
+│ Storage Layer    │  (DynamoDB table, JSONL file, S3)
+│ (at-rest data)   │
+└──────────────────┘
+         │  TRUST BOUNDARY
+         ▼
+┌──────────────────┐
+│ Verifier         │  (bh-audit verify CLI or verify_chain())
+│ (read-only)      │
+└──────────────────┘
+```
+
+### Key assumptions
+
+1. The application process is trusted at emission time.
+2. Storage is append-only or append-mostly (deletions are detectable).
+3. The verifier operates on a faithful copy of the stored data.
+4. Hash algorithms (SHA-256/384/512) are collision-resistant.
+
+## Recommendations for production deployments
+
+1. **Enable DynamoDB point-in-time recovery** for the audit table.
+2. **Run `bh-audit verify` on a schedule** (daily or weekly) from a
+   separate, hardened environment.
+3. **Archive audit events to S3 with Object Lock** for immutable retention.
+4. **Forward audit events to a SIEM** for independent correlation.
+5. **Monitor `chain_gaps_total` and `integrity_events_total`** in your
+   observability stack.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bh-fastapi-audit"
-version = "0.4.0"
+version = "0.5.0"
 description = "FastAPI ASGI middleware for emitting PHI-safe audit events for behavioral healthcare systems"
 readme = "README.md"
 license = "Apache-2.0"
@@ -49,6 +49,7 @@ dev = [
     "moto[dynamodb]>=5.0,<6",      # AWS service mocking for DynamoDB tests
     "boto3>=1.34,<2",              # Needed at test time for DynamoDB sink tests
     "jsonschema>=4.20,<5",         # Needed at test time for validation tests
+    "typer>=0.9,<1",               # CLI tests
 ]
 jsonschema = [
     "jsonschema>=4.20,<5",         # Runtime schema validation (opt-in via validate_events=True)
@@ -59,6 +60,12 @@ sqlalchemy = [
 dynamodb = [
     "boto3>=1.34,<2",              # AWS SDK for DynamoDB audit sink
 ]
+cli = [
+    "typer>=0.9,<1",               # Verifier CLI (bh-audit verify)
+]
+
+[project.scripts]
+bh-audit = "bh_fastapi_audit.cli:app"
 
 [project.urls]
 Homepage = "https://github.com/bh-healthcare/bh-fastapi-audit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bh-fastapi-audit"
-version = "0.5.0"
+version = "1.0.0"
 description = "FastAPI ASGI middleware for emitting PHI-safe audit events for behavioral healthcare systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/bh_fastapi_audit/__init__.py
+++ b/src/bh_fastapi_audit/__init__.py
@@ -5,7 +5,7 @@ This package provides pure ASGI middleware for emitting structured audit events
 conforming to the bh-audit-schema v1.1 standard for behavioral healthcare systems.
 """
 
-__version__ = "0.5.0"
+__version__ = "1.0.0"
 
 from bh_fastapi_audit._chain import canonical_serialize, compute_chain_hash
 from bh_fastapi_audit._chain_state import ChainState

--- a/src/bh_fastapi_audit/__init__.py
+++ b/src/bh_fastapi_audit/__init__.py
@@ -5,7 +5,7 @@ This package provides pure ASGI middleware for emitting structured audit events
 conforming to the bh-audit-schema v1.1 standard for behavioral healthcare systems.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from bh_fastapi_audit._chain import canonical_serialize, compute_chain_hash
 from bh_fastapi_audit._chain_state import ChainState
@@ -29,6 +29,7 @@ from bh_fastapi_audit._types import (
     ServiceBlock,
 )
 from bh_fastapi_audit._validation import AuditValidationError, validate_event
+from bh_fastapi_audit._verifier import VerifyFailure, VerifyResult, verify_chain
 from bh_fastapi_audit.middleware import AuditConfig, AuditMiddleware
 from bh_fastapi_audit.redaction import (
     contains_phi_tokens,
@@ -109,6 +110,10 @@ __all__ = [
     "LoggingSink",
     "MemorySink",
     "SQLAlchemySink",
+    # Verifier
+    "VerifyFailure",
+    "VerifyResult",
+    "verify_chain",
     # Validation
     "validate_event",
     # Redaction utilities

--- a/src/bh_fastapi_audit/_queue.py
+++ b/src/bh_fastapi_audit/_queue.py
@@ -31,6 +31,8 @@ class EmitQueue:
             ``"log"`` inside the background task because there is no
             caller to propagate to.
         failure_logger: Logger instance for internal diagnostics.
+        telemetry: Optional ``TelemetryEmitter`` for accurate
+            post-emit tracking.
     """
 
     __slots__ = (
@@ -40,6 +42,7 @@ class EmitQueue:
         "_emit_failure_mode",
         "_failure_log",
         "_task",
+        "_telemetry",
     )
 
     def __init__(
@@ -50,6 +53,7 @@ class EmitQueue:
         maxsize: int = 10_000,
         emit_failure_mode: str = "log",
         failure_logger: logging.Logger | None = None,
+        telemetry: Any = None,
     ) -> None:
         self._sink = sink
         self._stats = stats
@@ -57,6 +61,7 @@ class EmitQueue:
         self._emit_failure_mode = emit_failure_mode
         self._failure_log = failure_logger or _log
         self._task: asyncio.Task[None] | None = None
+        self._telemetry = telemetry
 
     @property
     def pending(self) -> int:
@@ -115,6 +120,11 @@ class EmitQueue:
                 await loop.run_in_executor(None, self._sink.emit, event)
             except Exception as exc:
                 self._stats.increment("emit_failures_total")
+                if self._telemetry is not None:
+                    try:
+                        self._telemetry.record_failure()
+                    except Exception:
+                        pass
                 if self._emit_failure_mode in ("log", "raise"):
                     self._failure_log.warning(
                         "Audit sink emit failed: event_id=%s service=%s error=%s",
@@ -124,5 +134,10 @@ class EmitQueue:
                     )
             else:
                 self._stats.increment("events_emitted_total")
+                if self._telemetry is not None:
+                    try:
+                        self._telemetry.record(event)
+                    except Exception:
+                        pass
             finally:
                 self._queue.task_done()

--- a/src/bh_fastapi_audit/_telemetry.py
+++ b/src/bh_fastapi_audit/_telemetry.py
@@ -122,8 +122,6 @@ class TelemetryCounters:
 def _next_sunday(dt: datetime) -> datetime:
     """Return the start of the next Sunday (UTC midnight) after *dt*."""
     days_until_sunday = (6 - dt.weekday()) % 7
-    if days_until_sunday == 0 and dt.hour == 0 and dt.minute == 0:
-        days_until_sunday = 7
     target = dt.date() + timedelta(days=days_until_sunday or 7)
     return datetime(target.year, target.month, target.day, tzinfo=UTC)
 
@@ -151,7 +149,9 @@ class TelemetryEmitter:
         self._package_version = package_version
         self._counters = TelemetryCounters()
         self._deployment_id: str | None = None
-        self._period_end = _next_sunday(datetime.now(UTC))
+        now = datetime.now(UTC)
+        self._period_start = now
+        self._period_end = _next_sunday(now)
 
     @property
     def counters(self) -> TelemetryCounters:
@@ -182,9 +182,7 @@ class TelemetryEmitter:
                 environment=self._environment,
                 package_version=self._package_version,
             )
-            report["period_start"] = (
-                self._period_end - timedelta(days=_DEFAULT_PERIOD_DAYS)
-            ).isoformat()
+            report["period_start"] = self._period_start.isoformat()
             report["period_end"] = self._period_end.isoformat()
 
             body = json.dumps(report).encode("utf-8")
@@ -196,6 +194,7 @@ class TelemetryEmitter:
             )
             urlopen(req, timeout=_HTTP_TIMEOUT_S)  # noqa: S310
             self._counters.reset()
+            self._period_start = now
         except Exception:
             _log.debug("Telemetry emission failed (silently swallowed)", exc_info=True)
         finally:

--- a/src/bh_fastapi_audit/_telemetry.py
+++ b/src/bh_fastapi_audit/_telemetry.py
@@ -1,0 +1,230 @@
+"""
+Opt-in, privacy-first telemetry emitter.
+
+Collects **counter-based aggregate statistics only** -- no PII, no PHI,
+no event content, no IP addresses.  Designed for Lambda-friendly
+environments (no background threads).
+
+Off by default.  Enable via ``AuditConfig(telemetry_enabled=True)``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.request import Request, urlopen
+
+_log = logging.getLogger("bh.audit.telemetry")
+
+_TELEMETRY_SCHEMA_VERSION = "1.0"
+_DEFAULT_PERIOD_DAYS = 7  # Sunday-to-Sunday windows
+_HTTP_TIMEOUT_S = 5
+_DEPLOYMENT_ID_FILE = ".bh-audit-deployment-id"
+
+
+class TelemetryCounters:
+    """Thread-safe aggregate counters -- no PII, no PHI."""
+
+    __slots__ = (
+        "_lock",
+        "events_emitted",
+        "by_action_type",
+        "by_outcome",
+        "by_data_classification",
+        "integrity_events",
+        "chain_gaps",
+        "emit_failures",
+    )
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.events_emitted: int = 0
+        self.by_action_type: dict[str, int] = {}
+        self.by_outcome: dict[str, int] = {}
+        self.by_data_classification: dict[str, int] = {}
+        self.integrity_events: int = 0
+        self.chain_gaps: int = 0
+        self.emit_failures: int = 0
+
+    def increment(self, event: dict[str, Any]) -> None:
+        """Tally a single event (thread-safe)."""
+        action_type = event.get("action", {}).get("type", "UNKNOWN")
+        outcome = event.get("outcome", {}).get("status", "UNKNOWN")
+        classification = event.get("action", {}).get("data_classification", "UNKNOWN")
+        has_integrity = "integrity" in event
+
+        with self._lock:
+            self.events_emitted += 1
+            self.by_action_type[action_type] = self.by_action_type.get(action_type, 0) + 1
+            self.by_outcome[outcome] = self.by_outcome.get(outcome, 0) + 1
+            self.by_data_classification[classification] = (
+                self.by_data_classification.get(classification, 0) + 1
+            )
+            if has_integrity:
+                self.integrity_events += 1
+
+    def increment_failure(self) -> None:
+        """Record a single emit failure (thread-safe)."""
+        with self._lock:
+            self.emit_failures += 1
+
+    def increment_chain_gap(self) -> None:
+        """Record a single chain gap (thread-safe)."""
+        with self._lock:
+            self.chain_gaps += 1
+
+    def to_report(
+        self,
+        deployment_id: str,
+        service_name: str,
+        environment: str,
+        package_version: str,
+    ) -> dict[str, Any]:
+        """Snapshot counters into a telemetry report payload."""
+        with self._lock:
+            return {
+                "schema_version": _TELEMETRY_SCHEMA_VERSION,
+                "deployment_id": deployment_id,
+                "service_name": service_name,
+                "environment": environment,
+                "package": "bh-fastapi-audit",
+                "package_version": package_version,
+                "period_start": None,
+                "period_end": None,
+                "counters": {
+                    "events_emitted": self.events_emitted,
+                    "by_action_type": dict(self.by_action_type),
+                    "by_outcome": dict(self.by_outcome),
+                    "by_data_classification": dict(self.by_data_classification),
+                    "integrity_events": self.integrity_events,
+                    "chain_gaps": self.chain_gaps,
+                    "emit_failures": self.emit_failures,
+                },
+            }
+
+    def reset(self) -> None:
+        """Zero all counters (called after successful emission)."""
+        with self._lock:
+            self.events_emitted = 0
+            self.by_action_type.clear()
+            self.by_outcome.clear()
+            self.by_data_classification.clear()
+            self.integrity_events = 0
+            self.chain_gaps = 0
+            self.emit_failures = 0
+
+
+def _next_sunday(dt: datetime) -> datetime:
+    """Return the start of the next Sunday (UTC midnight) after *dt*."""
+    days_until_sunday = (6 - dt.weekday()) % 7
+    if days_until_sunday == 0 and dt.hour == 0 and dt.minute == 0:
+        days_until_sunday = 7
+    target = dt.date() + timedelta(days=days_until_sunday or 7)
+    return datetime(target.year, target.month, target.day, tzinfo=UTC)
+
+
+class TelemetryEmitter:
+    """Counter-based period-check emitter.
+
+    On each ``record()`` call, counters are incremented and the period
+    boundary is checked.  If the period has elapsed, the report is
+    POSTed via urllib and counters are reset.  No background threads.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        deployment_id_path: str,
+        service_name: str,
+        environment: str,
+        package_version: str,
+    ) -> None:
+        self._endpoint = endpoint
+        self._deployment_id_path = deployment_id_path
+        self._service_name = service_name
+        self._environment = environment
+        self._package_version = package_version
+        self._counters = TelemetryCounters()
+        self._deployment_id: str | None = None
+        self._period_end = _next_sunday(datetime.now(UTC))
+
+    @property
+    def counters(self) -> TelemetryCounters:
+        return self._counters
+
+    def record(self, event: dict[str, Any]) -> None:
+        """Increment counters and emit if period boundary crossed."""
+        self._counters.increment(event)
+        now = datetime.now(UTC)
+        if now >= self._period_end:
+            self._emit_report(now)
+
+    def record_failure(self) -> None:
+        """Record an emit failure."""
+        self._counters.increment_failure()
+
+    def record_chain_gap(self) -> None:
+        """Record a chain gap."""
+        self._counters.increment_chain_gap()
+
+    def _emit_report(self, now: datetime) -> None:
+        """POST the telemetry report. Failures are silently swallowed."""
+        try:
+            deployment_id = self._get_or_create_deployment_id()
+            report = self._counters.to_report(
+                deployment_id=deployment_id,
+                service_name=self._service_name,
+                environment=self._environment,
+                package_version=self._package_version,
+            )
+            report["period_start"] = (
+                self._period_end - timedelta(days=_DEFAULT_PERIOD_DAYS)
+            ).isoformat()
+            report["period_end"] = self._period_end.isoformat()
+
+            body = json.dumps(report).encode("utf-8")
+            req = Request(
+                self._endpoint,
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            urlopen(req, timeout=_HTTP_TIMEOUT_S)  # noqa: S310
+            self._counters.reset()
+        except Exception:
+            _log.debug("Telemetry emission failed (silently swallowed)", exc_info=True)
+        finally:
+            self._period_end = _next_sunday(now)
+
+    def _get_or_create_deployment_id(self) -> str:
+        """Read or create an anonymous deployment UUID."""
+        if self._deployment_id is not None:
+            return self._deployment_id
+
+        id_dir = self._deployment_id_path
+        id_file = os.path.join(id_dir, _DEPLOYMENT_ID_FILE)
+
+        try:
+            with open(id_file, encoding="utf-8") as fh:
+                cached = fh.read().strip()
+                if cached:
+                    self._deployment_id = cached
+                    return cached
+        except FileNotFoundError:
+            pass
+
+        new_id = str(uuid.uuid4())
+        try:
+            os.makedirs(id_dir, exist_ok=True)
+            with open(id_file, "w", encoding="utf-8") as fh:
+                fh.write(new_id)
+        except OSError:
+            _log.debug("Could not persist deployment ID to %s", id_file)
+
+        self._deployment_id = new_id
+        return new_id

--- a/src/bh_fastapi_audit/_verifier.py
+++ b/src/bh_fastapi_audit/_verifier.py
@@ -1,0 +1,159 @@
+"""
+Chain integrity verification for tamper-evident audit trails.
+
+Provides a pure-function verifier that walks an ordered sequence of
+audit events, recomputes each event's chain hash, and compares it to
+the recorded integrity block.  The result is a structured report
+suitable for compliance review or CI pipeline assertions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from bh_fastapi_audit._chain import compute_chain_hash
+
+
+@dataclass
+class VerifyFailure:
+    """A single integrity violation found during chain verification."""
+
+    event_index: int
+    event_id: str
+    timestamp: str
+    failure_type: Literal["hash_mismatch", "chain_gap"]
+    expected: str | None
+    actual: str | None
+    message: str
+
+
+@dataclass
+class VerifyResult:
+    """Outcome of a chain verification run."""
+
+    events_scanned: int
+    time_range_start: str | None
+    time_range_end: str | None
+    chain_length: int
+    chain_gaps: int
+    hash_mismatches: int
+    unchained_events: int
+    result: Literal["PASS", "FAIL"]
+    failures: list[VerifyFailure] = field(default_factory=list)
+
+
+def verify_chain(
+    events: Iterable[dict[str, Any]],
+    algorithm: str = "sha256",
+) -> VerifyResult:
+    """Walk *events* in order, recompute hashes, and compare to stored integrity.
+
+    Each event is expected to carry an ``integrity`` block with at least
+    ``event_hash`` and ``hash_alg``.  Events without an ``integrity``
+    block are counted as *unchained* but do not cause a FAIL on their own.
+
+    Args:
+        events: Ordered iterable of audit event dicts.
+        algorithm: Default hash algorithm when ``integrity.hash_alg`` is
+                   absent.  Normally read from each event's integrity block.
+
+    Returns:
+        A ``VerifyResult`` summarising the verification.
+    """
+    failures: list[VerifyFailure] = []
+    prev_hash: str | None = None
+    chain_length = 0
+    chain_gaps = 0
+    hash_mismatches = 0
+    unchained_events = 0
+    first_ts: str | None = None
+    last_ts: str | None = None
+    scanned = 0
+
+    for idx, event in enumerate(events):
+        scanned += 1
+        ts = event.get("timestamp", "")
+        eid = event.get("event_id", "unknown")
+
+        if first_ts is None:
+            first_ts = ts
+        last_ts = ts
+
+        integrity = event.get("integrity")
+        if integrity is None:
+            unchained_events += 1
+            prev_hash = None
+            continue
+
+        chain_length += 1
+        alg = integrity.get("hash_alg", algorithm)
+        recorded_hash = integrity.get("event_hash", "")
+
+        recomputed = compute_chain_hash(event, prev_hash, alg)
+        recomputed_hash = recomputed["event_hash"]
+
+        if recomputed_hash != recorded_hash:
+            hash_mismatches += 1
+            failures.append(
+                VerifyFailure(
+                    event_index=idx,
+                    event_id=eid,
+                    timestamp=ts,
+                    failure_type="hash_mismatch",
+                    expected=recomputed_hash,
+                    actual=recorded_hash,
+                    message=(
+                        "Event content does not match its recorded hash. "
+                        "Event may have been modified after emission."
+                    ),
+                )
+            )
+
+        recorded_prev = integrity.get("prev_event_hash")
+        if chain_length > 1 and recorded_prev is None:
+            chain_gaps += 1
+            failures.append(
+                VerifyFailure(
+                    event_index=idx,
+                    event_id=eid,
+                    timestamp=ts,
+                    failure_type="chain_gap",
+                    expected=prev_hash,
+                    actual=None,
+                    message="Missing prev_event_hash mid-chain (possible unchained emission).",
+                )
+            )
+        elif recorded_prev is not None and recorded_prev != prev_hash:
+            chain_gaps += 1
+            failures.append(
+                VerifyFailure(
+                    event_index=idx,
+                    event_id=eid,
+                    timestamp=ts,
+                    failure_type="chain_gap",
+                    expected=prev_hash,
+                    actual=recorded_prev,
+                    message=(
+                        "prev_event_hash does not match the previous event's hash. "
+                        "An event may have been deleted or reordered."
+                    ),
+                )
+            )
+
+        prev_hash = recorded_hash
+
+    ok = hash_mismatches == 0 and chain_gaps == 0
+
+    return VerifyResult(
+        events_scanned=scanned,
+        time_range_start=first_ts or None,
+        time_range_end=last_ts or None,
+        chain_length=chain_length,
+        chain_gaps=chain_gaps,
+        hash_mismatches=hash_mismatches,
+        unchained_events=unchained_events,
+        result="PASS" if ok else "FAIL",
+        failures=failures,
+    )

--- a/src/bh_fastapi_audit/cli.py
+++ b/src/bh_fastapi_audit/cli.py
@@ -1,0 +1,199 @@
+"""
+``bh-audit`` CLI -- audit infrastructure tools.
+
+Requires the ``[cli]`` extra: ``pip install bh-fastapi-audit[cli]``
+
+Usage::
+
+    bh-audit verify --source file --path /var/log/audit/events.jsonl
+    bh-audit verify --source dynamodb --table bh_audit_events --service intake-api
+    bh-audit verify --source file --path events.jsonl --format json
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+try:
+    import typer
+except ImportError as _exc:
+    raise ImportError(
+        "The bh-audit CLI requires typer. Install with: pip install bh-fastapi-audit[cli]"
+    ) from _exc
+
+from bh_fastapi_audit._verifier import VerifyResult, verify_chain
+
+app = typer.Typer(name="bh-audit", help="BH Audit infrastructure tools")
+
+_EXIT_PASS = 0
+_EXIT_FAIL = 1
+_EXIT_ERROR = 2
+
+
+def _load_events_from_file(path: str) -> list[dict[str, Any]]:
+    """Read audit events from a JSONL file."""
+    events: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                typer.echo(f"Error: invalid JSON on line {lineno}: {exc}", err=True)
+                raise typer.Exit(code=_EXIT_ERROR) from exc
+    return events
+
+
+def _load_events_from_dynamodb(
+    table: str,
+    service: str | None,
+    start: str | None,
+    end: str | None,
+    region: str | None,
+) -> list[dict[str, Any]]:
+    """Query audit events from a DynamoDB table."""
+    try:
+        from bh_fastapi_audit.sinks.dynamodb import DynamoDBSink
+    except ImportError as exc:
+        typer.echo(
+            "Error: DynamoDB source requires boto3. "
+            "Install with: pip install bh-fastapi-audit[dynamodb]",
+            err=True,
+        )
+        raise typer.Exit(code=_EXIT_ERROR) from exc
+
+    kwargs: dict[str, Any] = {"table_name": table}
+    if region:
+        kwargs["region"] = region
+    sink = DynamoDBSink(**kwargs)
+
+    if service:
+        return sink.query_by_actor(service, start=start, end=end)
+    return sink.query_by_patient("*", start=start, end=end)
+
+
+def _format_human(result: VerifyResult, source_label: str) -> str:
+    """Render a human-readable verification report."""
+    lines = [
+        "bh-audit verify",
+        "",
+        f"Source: {source_label}",
+        f"Events scanned: {result.events_scanned:,}",
+    ]
+    if result.time_range_start and result.time_range_end:
+        lines.append(f"Time range: {result.time_range_start} to {result.time_range_end}")
+
+    lines.append("")
+    lines.append("Chain verification:")
+    lines.append(f"  Chain length:      {result.chain_length:,}")
+    lines.append(f"  Chain gaps:        {result.chain_gaps}")
+    lines.append(f"  Hash mismatches:   {result.hash_mismatches}")
+    if result.unchained_events > 0:
+        lines.append(f"  Unchained events:  {result.unchained_events}")
+
+    for failure in result.failures:
+        lines.append("")
+        lines.append(f"FAILURE at event #{failure.event_index}:")
+        lines.append(f"  event_id:       {failure.event_id}")
+        lines.append(f"  timestamp:      {failure.timestamp}")
+        lines.append(f"  type:           {failure.failure_type}")
+        if failure.expected is not None:
+            lines.append(f"  expected_hash:  {failure.expected}")
+        if failure.actual is not None:
+            lines.append(f"  actual_hash:    {failure.actual}")
+        lines.append(f"  detail:         {failure.message}")
+
+    lines.append("")
+    if result.result == "PASS":
+        lines.append("Result: PASS - audit chain is intact")
+        lines.append("")
+        lines.append("Compliance note:")
+        lines.append(f"  All {result.chain_length:,} chained events have valid integrity hashes.")
+        lines.append("  No evidence of tampering or silent deletion detected.")
+    else:
+        lines.append("Result: FAIL - integrity violation detected")
+        lines.append("")
+        lines.append("Recommended action:")
+        lines.append("  Investigate the flagged events and surrounding context.")
+        lines.append("  Preserve original audit logs for forensic review.")
+
+    return "\n".join(lines)
+
+
+def _format_json(result: VerifyResult, source_label: str) -> str:
+    """Render a machine-readable JSON verification report."""
+    payload: dict[str, Any] = {
+        "source": source_label,
+        "events_scanned": result.events_scanned,
+        "time_range": {
+            "start": result.time_range_start,
+            "end": result.time_range_end,
+        },
+        "chain_length": result.chain_length,
+        "chain_gaps": result.chain_gaps,
+        "hash_mismatches": result.hash_mismatches,
+        "unchained_events": result.unchained_events,
+        "result": result.result,
+        "failures": [
+            {
+                "event_index": f.event_index,
+                "event_id": f.event_id,
+                "timestamp": f.timestamp,
+                "failure_type": f.failure_type,
+                "expected": f.expected,
+                "actual": f.actual,
+                "message": f.message,
+            }
+            for f in result.failures
+        ],
+    }
+    return json.dumps(payload, indent=2)
+
+
+@app.command()
+def verify(
+    source: str = typer.Option(..., help="Source type: 'file' or 'dynamodb'"),
+    path: str | None = typer.Option(None, help="Path to JSONL file (for --source file)"),
+    table: str | None = typer.Option(None, help="DynamoDB table name (for --source dynamodb)"),
+    service: str | None = typer.Option(None, help="Service name filter (for --source dynamodb)"),
+    start: str | None = typer.Option(None, help="Start date (ISO 8601)"),
+    end: str | None = typer.Option(None, help="End date (ISO 8601)"),
+    region: str | None = typer.Option(None, help="AWS region (for --source dynamodb)"),
+    output_format: str = typer.Option("human", "--format", help="Output format: 'human' or 'json'"),
+) -> None:
+    """Verify integrity of an audit event chain."""
+    if source == "file":
+        if not path:
+            typer.echo("Error: --path is required when --source is 'file'", err=True)
+            raise typer.Exit(code=_EXIT_ERROR)
+        try:
+            events = _load_events_from_file(path)
+        except FileNotFoundError as exc:
+            typer.echo(f"Error: file not found: {path}", err=True)
+            raise typer.Exit(code=_EXIT_ERROR) from exc
+        source_label = path
+    elif source == "dynamodb":
+        if not table:
+            typer.echo("Error: --table is required when --source is 'dynamodb'", err=True)
+            raise typer.Exit(code=_EXIT_ERROR)
+        events = _load_events_from_dynamodb(table, service, start, end, region)
+        source_label = f"dynamodb://{table}"
+    else:
+        typer.echo(f"Error: unknown source type '{source}'. Use 'file' or 'dynamodb'.", err=True)
+        raise typer.Exit(code=_EXIT_ERROR)
+
+    result = verify_chain(events)
+
+    if output_format == "json":
+        typer.echo(_format_json(result, source_label))
+    else:
+        typer.echo(_format_human(result, source_label))
+
+    raise typer.Exit(code=_EXIT_PASS if result.result == "PASS" else _EXIT_FAIL)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/bh_fastapi_audit/cli.py
+++ b/src/bh_fastapi_audit/cli.py
@@ -22,6 +22,7 @@ except ImportError as _exc:
         "The bh-audit CLI requires typer. Install with: pip install bh-fastapi-audit[cli]"
     ) from _exc
 
+from bh_fastapi_audit import __version__
 from bh_fastapi_audit._verifier import VerifyResult, verify_chain
 
 app = typer.Typer(name="bh-audit", help="BH Audit infrastructure tools")
@@ -49,12 +50,12 @@ def _load_events_from_file(path: str) -> list[dict[str, Any]]:
 
 def _load_events_from_dynamodb(
     table: str,
-    service: str | None,
+    service: str,
     start: str | None,
     end: str | None,
     region: str | None,
 ) -> list[dict[str, Any]]:
-    """Query audit events from a DynamoDB table."""
+    """Query audit events from a DynamoDB table via the actor-index GSI."""
     try:
         from bh_fastapi_audit.sinks.dynamodb import DynamoDBSink
     except ImportError as exc:
@@ -70,15 +71,13 @@ def _load_events_from_dynamodb(
         kwargs["region"] = region
     sink = DynamoDBSink(**kwargs)
 
-    if service:
-        return sink.query_by_actor(service, start=start, end=end)
-    return sink.query_by_patient("*", start=start, end=end)
+    return sink.query_by_actor(service, start=start, end=end)
 
 
 def _format_human(result: VerifyResult, source_label: str) -> str:
     """Render a human-readable verification report."""
     lines = [
-        "bh-audit verify",
+        f"bh-audit verify v{__version__}",
         "",
         f"Source: {source_label}",
         f"Events scanned: {result.events_scanned:,}",
@@ -126,6 +125,7 @@ def _format_human(result: VerifyResult, source_label: str) -> str:
 def _format_json(result: VerifyResult, source_label: str) -> str:
     """Render a machine-readable JSON verification report."""
     payload: dict[str, Any] = {
+        "version": __version__,
         "source": source_label,
         "events_scanned": result.events_scanned,
         "time_range": {
@@ -158,7 +158,10 @@ def verify(
     source: str = typer.Option(..., help="Source type: 'file' or 'dynamodb'"),
     path: str | None = typer.Option(None, help="Path to JSONL file (for --source file)"),
     table: str | None = typer.Option(None, help="DynamoDB table name (for --source dynamodb)"),
-    service: str | None = typer.Option(None, help="Service name filter (for --source dynamodb)"),
+    service: str | None = typer.Option(
+        None,
+        help="Service / actor name to query (for --source dynamodb)",
+    ),
     start: str | None = typer.Option(None, help="Start date (ISO 8601)"),
     end: str | None = typer.Option(None, help="End date (ISO 8601)"),
     region: str | None = typer.Option(None, help="AWS region (for --source dynamodb)"),
@@ -171,13 +174,16 @@ def verify(
             raise typer.Exit(code=_EXIT_ERROR)
         try:
             events = _load_events_from_file(path)
-        except FileNotFoundError as exc:
-            typer.echo(f"Error: file not found: {path}", err=True)
+        except OSError as exc:
+            typer.echo(f"Error: cannot read file: {path} ({exc})", err=True)
             raise typer.Exit(code=_EXIT_ERROR) from exc
         source_label = path
     elif source == "dynamodb":
         if not table:
             typer.echo("Error: --table is required when --source is 'dynamodb'", err=True)
+            raise typer.Exit(code=_EXIT_ERROR)
+        if not service:
+            typer.echo("Error: --service is required when --source is 'dynamodb'", err=True)
             raise typer.Exit(code=_EXIT_ERROR)
         events = _load_events_from_dynamodb(table, service, start, end, region)
         source_label = f"dynamodb://{table}"

--- a/src/bh_fastapi_audit/middleware.py
+++ b/src/bh_fastapi_audit/middleware.py
@@ -94,6 +94,11 @@ class AuditConfig:
     chain_state: Any = None
     hash_algorithm: HashAlgorithm = "sha256"
 
+    # Telemetry (v0.5) -- off by default, opt-in only
+    telemetry_enabled: bool = False
+    telemetry_endpoint: str = "https://abt0rxi196.execute-api.us-east-1.amazonaws.com/v1/report"
+    telemetry_deployment_id_path: str = "/tmp/bh-audit/"
+
     def __post_init__(self) -> None:
         if isinstance(self.metadata_allowlist, set):
             object.__setattr__(self, "metadata_allowlist", frozenset(self.metadata_allowlist))
@@ -136,6 +141,20 @@ class AuditMiddleware:
                 emit_failure_mode=config.emit_failure_mode,
                 failure_logger=self._failure_log,
             )
+
+        if config.telemetry_enabled:
+            from bh_fastapi_audit import __version__
+            from bh_fastapi_audit._telemetry import TelemetryEmitter
+
+            self._telemetry: TelemetryEmitter | None = TelemetryEmitter(
+                endpoint=config.telemetry_endpoint,
+                deployment_id_path=config.telemetry_deployment_id_path,
+                service_name=config.service_name,
+                environment=config.service_environment,
+                package_version=__version__,
+            )
+        else:
+            self._telemetry = None
 
     @property
     def stats(self) -> AuditStats:
@@ -261,12 +280,22 @@ class AuditMiddleware:
 
         if self._queue is not None:
             self._queue.enqueue(event)
+            if self._telemetry is not None:
+                try:
+                    self._telemetry.record(event)
+                except Exception:
+                    pass
             return
 
         try:
             self.sink.emit(event)
         except Exception as exc:
             self._stats.increment("emit_failures_total")
+            if self._telemetry is not None:
+                try:
+                    self._telemetry.record_failure()
+                except Exception:
+                    pass
             mode = self.config.emit_failure_mode
             if mode == "raise":
                 raise
@@ -281,6 +310,11 @@ class AuditMiddleware:
                 )
         else:
             self._stats.increment("events_emitted_total")
+            if self._telemetry is not None:
+                try:
+                    self._telemetry.record(event)
+                except Exception:
+                    pass
 
     # ------------------------------------------------------------------
     # Event construction

--- a/src/bh_fastapi_audit/middleware.py
+++ b/src/bh_fastapi_audit/middleware.py
@@ -94,7 +94,7 @@ class AuditConfig:
     chain_state: Any = None
     hash_algorithm: HashAlgorithm = "sha256"
 
-    # Telemetry (v0.5) -- off by default, opt-in only
+    # Telemetry (v1.0) -- off by default, opt-in only
     telemetry_enabled: bool = False
     telemetry_endpoint: str = "https://abt0rxi196.execute-api.us-east-1.amazonaws.com/v1/report"
     telemetry_deployment_id_path: str = "/tmp/bh-audit/"
@@ -132,16 +132,6 @@ class AuditMiddleware:
         self.config = config
         self._stats = AuditStats()
         self._failure_log = logging.getLogger(config.failure_logger_name)
-        self._queue: EmitQueue | None = None
-        if config.emit_mode == "queue":
-            self._queue = EmitQueue(
-                sink,
-                self._stats,
-                maxsize=config.queue_size,
-                emit_failure_mode=config.emit_failure_mode,
-                failure_logger=self._failure_log,
-            )
-
         if config.telemetry_enabled:
             from bh_fastapi_audit import __version__
             from bh_fastapi_audit._telemetry import TelemetryEmitter
@@ -155,6 +145,17 @@ class AuditMiddleware:
             )
         else:
             self._telemetry = None
+
+        self._queue: EmitQueue | None = None
+        if config.emit_mode == "queue":
+            self._queue = EmitQueue(
+                sink,
+                self._stats,
+                maxsize=config.queue_size,
+                emit_failure_mode=config.emit_failure_mode,
+                failure_logger=self._failure_log,
+                telemetry=self._telemetry,
+            )
 
     @property
     def stats(self) -> AuditStats:
@@ -277,14 +278,14 @@ class AuditMiddleware:
                 self._stats.increment("integrity_events_total")
             except Exception:
                 self._stats.increment("chain_gaps_total")
+                if self._telemetry is not None:
+                    try:
+                        self._telemetry.record_chain_gap()
+                    except Exception:
+                        pass
 
         if self._queue is not None:
             self._queue.enqueue(event)
-            if self._telemetry is not None:
-                try:
-                    self._telemetry.record(event)
-                except Exception:
-                    pass
             return
 
         try:

--- a/src/bh_fastapi_audit/sinks/dynamodb.py
+++ b/src/bh_fastapi_audit/sinks/dynamodb.py
@@ -121,46 +121,86 @@ class DynamoDBSink:
         elif end:
             key_cond &= Key("timestamp").lte(end)
 
-        resp = self._table.query(
+        return self._paginated_query(
             IndexName="patient_id-index",
             KeyConditionExpression=key_cond,
         )
-        return resp.get("Items", [])
 
     def query_by_actor(
         self,
         actor_id: str,
         start: str | None = None,
+        end: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Query GSI2 (actor-index) for user activity audit."""
+        """Query GSI2 (actor-index) for user activity audit.
+
+        Returns parsed audit events ordered by timestamp.
+        """
         from boto3.dynamodb.conditions import Key
 
         key_cond = Key("actor_subject_id").eq(actor_id)
-        if start:
+        if start and end:
+            key_cond &= Key("timestamp").between(start, end)
+        elif start:
             key_cond &= Key("timestamp").gte(start)
+        elif end:
+            key_cond &= Key("timestamp").lte(end)
 
-        resp = self._table.query(
+        return self._paginated_query(
             IndexName="actor-index",
             KeyConditionExpression=key_cond,
         )
-        return resp.get("Items", [])
 
     def query_denials(
         self,
         start: str | None = None,
+        end: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Query GSI3 (outcome-index) for all DENIED outcomes."""
+        """Query GSI3 (outcome-index) for all DENIED outcomes.
+
+        Returns parsed audit events ordered by timestamp.
+        """
         from boto3.dynamodb.conditions import Key
 
         key_cond = Key("outcome_status").eq("DENIED")
-        if start:
+        if start and end:
+            key_cond &= Key("timestamp").between(start, end)
+        elif start:
             key_cond &= Key("timestamp").gte(start)
+        elif end:
+            key_cond &= Key("timestamp").lte(end)
 
-        resp = self._table.query(
+        return self._paginated_query(
             IndexName="outcome-index",
             KeyConditionExpression=key_cond,
         )
-        return resp.get("Items", [])
+
+    # ------------------------------------------------------------------
+    # Pagination / parsing helpers
+    # ------------------------------------------------------------------
+
+    def _paginated_query(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """Execute a DynamoDB query, following all pagination tokens."""
+        items: list[dict[str, Any]] = []
+        while True:
+            resp = self._table.query(**kwargs)
+            items.extend(resp.get("Items", []))
+            if "LastEvaluatedKey" not in resp:
+                break
+            kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+        return self._parse_items(items)
+
+    @staticmethod
+    def _parse_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Parse ``event_json`` from DynamoDB items back into event dicts."""
+        results: list[dict[str, Any]] = []
+        for item in items:
+            raw = item.get("event_json")
+            if raw:
+                results.append(json.loads(raw))
+            else:
+                results.append(item)
+        return results
 
     # ------------------------------------------------------------------
     # Table creation (dev / test only)
@@ -199,11 +239,8 @@ class DynamoDBSink:
                                 "outcome_status",
                                 "data_classification",
                                 "http_route_template",
+                                "event_json",
                             ],
-                        },
-                        "ProvisionedThroughput": {
-                            "ReadCapacityUnits": 5,
-                            "WriteCapacityUnits": 5,
                         },
                     },
                     {
@@ -221,11 +258,8 @@ class DynamoDBSink:
                                 "patient_id",
                                 "outcome_status",
                                 "http_route_template",
+                                "event_json",
                             ],
-                        },
-                        "ProvisionedThroughput": {
-                            "ReadCapacityUnits": 5,
-                            "WriteCapacityUnits": 5,
                         },
                     },
                     {
@@ -243,19 +277,12 @@ class DynamoDBSink:
                                 "resource_type",
                                 "patient_id",
                                 "error_type",
+                                "event_json",
                             ],
-                        },
-                        "ProvisionedThroughput": {
-                            "ReadCapacityUnits": 5,
-                            "WriteCapacityUnits": 5,
                         },
                     },
                 ],
-                BillingMode="PROVISIONED",
-                ProvisionedThroughput={
-                    "ReadCapacityUnits": 5,
-                    "WriteCapacityUnits": 5,
-                },
+                BillingMode="PAY_PER_REQUEST",
             )
             self._table.wait_until_exists()
         except ClientError as exc:

--- a/src/bh_fastapi_audit/sinks/ledger.py
+++ b/src/bh_fastapi_audit/sinks/ledger.py
@@ -10,6 +10,7 @@ the previous event's hash.
 from __future__ import annotations
 
 import logging
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,7 @@ class LedgerSink:
         self._jsonl = JsonlFileSink(path, flush=flush)
         self._chain = ChainState()
         self._algorithm = algorithm
+        self._lock = threading.Lock()
 
     def emit(self, event: dict[str, Any]) -> None:
         """Hash, chain, and write *event* as a single JSONL line."""
@@ -50,10 +52,11 @@ class LedgerSink:
                 "LedgerSink: event already has integrity block (possible double-hashing); "
                 "overwriting with LedgerSink's own chain hash"
             )
-        integrity = compute_chain_hash(event, self._chain.last_hash, self._algorithm)
-        event["integrity"] = integrity
-        self._chain.advance(integrity["event_hash"])
-        self._jsonl.emit(event)
+        with self._lock:
+            integrity = compute_chain_hash(event, self._chain.last_hash, self._algorithm)
+            event = {**event, "integrity": integrity}
+            self._chain.advance(integrity["event_hash"])
+            self._jsonl.emit(event)
 
     def close(self) -> None:
         """Close the underlying file."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,6 +84,7 @@ class TestCliFileSourcePass:
                 ],
             )
             assert result.exit_code == 0
+            assert "bh-audit verify v" in result.stdout
             assert "Chain length:" in result.stdout
             assert "Chain gaps:" in result.stdout
         finally:
@@ -132,6 +133,7 @@ class TestCliJsonFormat:
             assert result.exit_code == 0
             payload = json.loads(result.stdout)
             assert payload["result"] == "PASS"
+            assert "version" in payload
             assert "events_scanned" in payload
             assert "failures" in payload
             assert isinstance(payload["failures"], list)
@@ -194,6 +196,10 @@ class TestCliErrors:
 
     def test_dynamodb_missing_table_exit_2(self) -> None:
         result = runner.invoke(app, ["--source", "dynamodb"])
+        assert result.exit_code == 2
+
+    def test_dynamodb_missing_service_exit_2(self) -> None:
+        result = runner.invoke(app, ["--source", "dynamodb", "--table", "t"])
         assert result.exit_code == 2
 
     def test_invalid_json_exit_2(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,217 @@
+"""Tests for bh_fastapi_audit.cli (bh-audit verify command)."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Any
+
+from typer.testing import CliRunner
+
+from bh_fastapi_audit._chain import compute_chain_hash
+from bh_fastapi_audit.cli import app
+
+runner = CliRunner()
+
+
+def _make_event(
+    event_id: str = "evt-001",
+    timestamp: str = "2026-01-01T00:00:00.000Z",
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.1",
+        "event_id": event_id,
+        "timestamp": timestamp,
+        "service": {"name": "test-svc", "environment": "test"},
+        "actor": {"subject_id": "user-1", "subject_type": "human"},
+        "action": {"type": "READ", "data_classification": "PHI"},
+        "resource": {"type": "Patient"},
+        "outcome": {"status": "SUCCESS"},
+    }
+
+
+def _build_chain(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    chain: list[dict[str, Any]] = []
+    prev_hash: str | None = None
+    for evt in events:
+        integrity = compute_chain_hash(evt, prev_hash)
+        chained = {**evt, "integrity": integrity}
+        prev_hash = integrity["event_hash"]
+        chain.append(chained)
+    return chain
+
+
+def _write_jsonl(events: list[dict[str, Any]], path: str) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for evt in events:
+            fh.write(json.dumps(evt) + "\n")
+
+
+class TestCliFileSourcePass:
+    def test_intact_chain_exit_0(self) -> None:
+        events = _build_chain(
+            [
+                _make_event("e1", "2026-01-01T00:00:00.000Z"),
+                _make_event("e2", "2026-01-01T00:01:00.000Z"),
+            ]
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            _write_jsonl(events, f.name)
+            path = f.name
+        try:
+            result = runner.invoke(app, ["--source", "file", "--path", path])
+            assert result.exit_code == 0
+            assert "PASS" in result.stdout
+        finally:
+            os.unlink(path)
+
+    def test_human_format_contains_chain_info(self) -> None:
+        events = _build_chain([_make_event()])
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            _write_jsonl(events, f.name)
+            path = f.name
+        try:
+            result = runner.invoke(
+                app,
+                [
+                    "--source",
+                    "file",
+                    "--path",
+                    path,
+                    "--format",
+                    "human",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Chain length:" in result.stdout
+            assert "Chain gaps:" in result.stdout
+        finally:
+            os.unlink(path)
+
+
+class TestCliFileSourceFail:
+    def test_broken_chain_exit_1(self) -> None:
+        events = _build_chain(
+            [
+                _make_event("e1", "2026-01-01T00:00:00.000Z"),
+                _make_event("e2", "2026-01-01T00:01:00.000Z"),
+            ]
+        )
+        events[1]["action"]["type"] = "DELETE"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            _write_jsonl(events, f.name)
+            path = f.name
+        try:
+            result = runner.invoke(app, ["--source", "file", "--path", path])
+            assert result.exit_code == 1
+            assert "FAIL" in result.stdout
+        finally:
+            os.unlink(path)
+
+
+class TestCliJsonFormat:
+    def test_json_output_valid(self) -> None:
+        events = _build_chain([_make_event()])
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            _write_jsonl(events, f.name)
+            path = f.name
+        try:
+            result = runner.invoke(
+                app,
+                [
+                    "--source",
+                    "file",
+                    "--path",
+                    path,
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            payload = json.loads(result.stdout)
+            assert payload["result"] == "PASS"
+            assert "events_scanned" in payload
+            assert "failures" in payload
+            assert isinstance(payload["failures"], list)
+        finally:
+            os.unlink(path)
+
+    def test_json_format_failure_details(self) -> None:
+        events = _build_chain(
+            [
+                _make_event("e1", "2026-01-01T00:00:00.000Z"),
+                _make_event("e2", "2026-01-01T00:01:00.000Z"),
+            ]
+        )
+        events[1]["service"]["name"] = "tampered"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            _write_jsonl(events, f.name)
+            path = f.name
+        try:
+            result = runner.invoke(
+                app,
+                [
+                    "--source",
+                    "file",
+                    "--path",
+                    path,
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 1
+            payload = json.loads(result.stdout)
+            assert payload["result"] == "FAIL"
+            assert len(payload["failures"]) >= 1
+            assert payload["failures"][0]["failure_type"] == "hash_mismatch"
+        finally:
+            os.unlink(path)
+
+
+class TestCliErrors:
+    def test_missing_path_exit_2(self) -> None:
+        result = runner.invoke(app, ["--source", "file"])
+        assert result.exit_code == 2
+
+    def test_nonexistent_file_exit_2(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--source",
+                "file",
+                "--path",
+                "/tmp/nonexistent_audit.jsonl",
+            ],
+        )
+        assert result.exit_code == 2
+
+    def test_invalid_source_type_exit_2(self) -> None:
+        result = runner.invoke(app, ["--source", "s3"])
+        assert result.exit_code == 2
+
+    def test_dynamodb_missing_table_exit_2(self) -> None:
+        result = runner.invoke(app, ["--source", "dynamodb"])
+        assert result.exit_code == 2
+
+    def test_invalid_json_exit_2(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            f.write("not valid json\n")
+            path = f.name
+        try:
+            result = runner.invoke(app, ["--source", "file", "--path", path])
+            assert result.exit_code == 2
+        finally:
+            os.unlink(path)
+
+    def test_empty_file_pass(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            result = runner.invoke(app, ["--source", "file", "--path", path])
+            assert result.exit_code == 0
+            assert "PASS" in result.stdout
+        finally:
+            os.unlink(path)

--- a/tests/test_dynamodb_chain_integration.py
+++ b/tests/test_dynamodb_chain_integration.py
@@ -393,8 +393,8 @@ class TestEdgeCases:
         assert results[0]["event_id"] == "gsi-test-001"
         # chain_hash is NOT in the GSI projection — verify that the
         # projected attributes are correct for chained events
-        assert results[0]["outcome_status"] == "SUCCESS"
-        assert results[0]["actor_subject_id"] == "user-1"
+        assert results[0]["outcome"]["status"] == "SUCCESS"
+        assert results[0]["actor"]["subject_id"] == "user-1"
 
     def test_full_table_scan_includes_chain_hash(self, infra):
         """A table scan (not GSI) should include chain_hash."""

--- a/tests/test_dynamodb_sink.py
+++ b/tests/test_dynamodb_sink.py
@@ -158,7 +158,7 @@ class TestQueryByPatient:
 
         results = sink.query_by_patient("pat_100")
         assert len(results) == 2
-        assert all(r["patient_id"] == "pat_100" for r in results)
+        assert all(r["resource"]["patient_id"] == "pat_100" for r in results)
 
     def test_returns_empty_for_unknown_patient(self, sink):
         sink.emit(_make_event(resource={"type": "Patient", "patient_id": "pat_100"}))
@@ -236,7 +236,7 @@ class TestQueryDenials:
 
         results = sink.query_denials()
         assert len(results) == 2
-        assert all(r["outcome_status"] == "DENIED" for r in results)
+        assert all(r["outcome"]["status"] == "DENIED" for r in results)
 
     def test_filters_by_start(self, sink):
         sink.emit(

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -129,7 +129,7 @@ def test_version_exposed():
     from bh_fastapi_audit import __version__
 
     assert isinstance(__version__, str)
-    assert __version__ == "0.5.0"
+    assert __version__ == "1.0.0"
 
 
 def test_all_exports_defined():

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -21,12 +21,15 @@ def test_public_api_imports():
         LedgerSink,
         LoggingSink,
         MemorySink,
+        VerifyFailure,
+        VerifyResult,
         canonical_serialize,
         compute_chain_hash,
         contains_phi_tokens,
         redact_tokens,
         sanitize_error_message,
         validate_event,
+        verify_chain,
     )
 
     assert AuditMiddleware is not None
@@ -45,6 +48,9 @@ def test_public_api_imports():
     assert callable(contains_phi_tokens)
     assert callable(redact_tokens)
     assert callable(validate_event)
+    assert callable(verify_chain)
+    assert VerifyResult is not None
+    assert VerifyFailure is not None
 
 
 def test_typed_event_blocks_importable():
@@ -123,7 +129,7 @@ def test_version_exposed():
     from bh_fastapi_audit import __version__
 
     assert isinstance(__version__, str)
-    assert __version__ == "0.4.0"
+    assert __version__ == "0.5.0"
 
 
 def test_all_exports_defined():
@@ -166,6 +172,10 @@ def test_all_exports_defined():
         "LoggingSink",
         "MemorySink",
         "SQLAlchemySink",
+        # Verifier
+        "VerifyFailure",
+        "VerifyResult",
+        "verify_chain",
         # Validation
         "validate_event",
         # Redaction

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -83,14 +83,14 @@ class TestTelemetryCounters:
     def test_to_report_structure(self) -> None:
         c = TelemetryCounters()
         c.increment(_make_event())
-        report = c.to_report("deploy-id", "svc", "staging", "0.5.0")
+        report = c.to_report("deploy-id", "svc", "staging", "1.0.0")
 
         assert report["schema_version"] == "1.0"
         assert report["deployment_id"] == "deploy-id"
         assert report["service_name"] == "svc"
         assert report["environment"] == "staging"
         assert report["package"] == "bh-fastapi-audit"
-        assert report["package_version"] == "0.5.0"
+        assert report["package_version"] == "1.0.0"
         assert "counters" in report
         counters = report["counters"]
         assert counters["events_emitted"] == 1
@@ -99,7 +99,7 @@ class TestTelemetryCounters:
     def test_to_report_no_pii(self) -> None:
         c = TelemetryCounters()
         c.increment(_make_event())
-        report = c.to_report("id", "svc", "prod", "0.5.0")
+        report = c.to_report("id", "svc", "prod", "1.0.0")
         serialized = json.dumps(report)
         for keyword in ["patient", "user-1", "ssn", "email", "phone"]:
             assert keyword not in serialized.lower()
@@ -147,7 +147,7 @@ class TestTelemetryEmitter:
                 deployment_id_path=tmpdir,
                 service_name="test-svc",
                 environment="test",
-                package_version="0.5.0",
+                package_version="1.0.0",
             )
             with patch("bh_fastapi_audit._telemetry.urlopen") as mock_urlopen:
                 emitter.record(_make_event())
@@ -161,7 +161,7 @@ class TestTelemetryEmitter:
                 deployment_id_path=tmpdir,
                 service_name="test-svc",
                 environment="test",
-                package_version="0.5.0",
+                package_version="1.0.0",
             )
             emitter._period_end = datetime.now(UTC) - timedelta(seconds=1)
 
@@ -176,7 +176,7 @@ class TestTelemetryEmitter:
                 deployment_id_path=tmpdir,
                 service_name="test-svc",
                 environment="test",
-                package_version="0.5.0",
+                package_version="1.0.0",
             )
             emitter._period_end = datetime.now(UTC) - timedelta(seconds=1)
 
@@ -192,7 +192,7 @@ class TestTelemetryEmitter:
                 deployment_id_path=tmpdir,
                 service_name="test-svc",
                 environment="test",
-                package_version="0.5.0",
+                package_version="1.0.0",
             )
             id1 = emitter._get_or_create_deployment_id()
             id2 = emitter._get_or_create_deployment_id()
@@ -204,7 +204,7 @@ class TestTelemetryEmitter:
                 deployment_id_path=tmpdir,
                 service_name="test-svc",
                 environment="test",
-                package_version="0.5.0",
+                package_version="1.0.0",
             )
             assert emitter2._get_or_create_deployment_id() == id1
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,221 @@
+"""Tests for bh_fastapi_audit._telemetry."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+
+from bh_fastapi_audit._telemetry import (
+    TelemetryCounters,
+    TelemetryEmitter,
+    _next_sunday,
+)
+
+
+def _make_event(
+    action_type: str = "READ",
+    outcome: str = "SUCCESS",
+    classification: str = "PHI",
+    with_integrity: bool = False,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "action": {"type": action_type, "data_classification": classification},
+        "outcome": {"status": outcome},
+    }
+    if with_integrity:
+        event["integrity"] = {"event_hash": "abc123", "hash_alg": "sha256"}
+    return event
+
+
+class TestTelemetryCounters:
+    def test_increment_tallies_by_action_type(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event(action_type="READ"))
+        c.increment(_make_event(action_type="READ"))
+        c.increment(_make_event(action_type="CREATE"))
+        assert c.by_action_type == {"READ": 2, "CREATE": 1}
+        assert c.events_emitted == 3
+
+    def test_increment_tallies_by_outcome(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event(outcome="SUCCESS"))
+        c.increment(_make_event(outcome="FAILURE"))
+        assert c.by_outcome == {"SUCCESS": 1, "FAILURE": 1}
+
+    def test_increment_tallies_by_classification(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event(classification="PHI"))
+        c.increment(_make_event(classification="RESTRICTED"))
+        assert c.by_data_classification == {"PHI": 1, "RESTRICTED": 1}
+
+    def test_integrity_events_counted(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event(with_integrity=True))
+        c.increment(_make_event(with_integrity=False))
+        assert c.integrity_events == 1
+
+    def test_increment_failure(self) -> None:
+        c = TelemetryCounters()
+        c.increment_failure()
+        c.increment_failure()
+        assert c.emit_failures == 2
+
+    def test_increment_chain_gap(self) -> None:
+        c = TelemetryCounters()
+        c.increment_chain_gap()
+        assert c.chain_gaps == 1
+
+    def test_reset_zeros_all(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event())
+        c.increment_failure()
+        c.increment_chain_gap()
+        c.reset()
+        assert c.events_emitted == 0
+        assert c.by_action_type == {}
+        assert c.emit_failures == 0
+        assert c.chain_gaps == 0
+
+    def test_to_report_structure(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event())
+        report = c.to_report("deploy-id", "svc", "staging", "0.5.0")
+
+        assert report["schema_version"] == "1.0"
+        assert report["deployment_id"] == "deploy-id"
+        assert report["service_name"] == "svc"
+        assert report["environment"] == "staging"
+        assert report["package"] == "bh-fastapi-audit"
+        assert report["package_version"] == "0.5.0"
+        assert "counters" in report
+        counters = report["counters"]
+        assert counters["events_emitted"] == 1
+        assert "by_action_type" in counters
+
+    def test_to_report_no_pii(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event())
+        report = c.to_report("id", "svc", "prod", "0.5.0")
+        serialized = json.dumps(report)
+        for keyword in ["patient", "user-1", "ssn", "email", "phone"]:
+            assert keyword not in serialized.lower()
+
+    def test_thread_safety(self) -> None:
+        c = TelemetryCounters()
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                for _ in range(100):
+                    c.increment(_make_event())
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert c.events_emitted == 1000
+
+
+class TestNextSunday:
+    def test_monday_to_sunday(self) -> None:
+        monday = datetime(2026, 3, 30, 10, 0, tzinfo=UTC)
+        sunday = _next_sunday(monday)
+        assert sunday.weekday() == 6
+        assert sunday > monday
+
+    def test_sunday_midnight_advances_week(self) -> None:
+        sunday = datetime(2026, 4, 5, 0, 0, tzinfo=UTC)
+        next_sun = _next_sunday(sunday)
+        assert next_sun > sunday
+        assert next_sun.weekday() == 6
+
+
+class TestTelemetryEmitter:
+    def test_record_does_not_emit_mid_period(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = TelemetryEmitter(
+                endpoint="https://example.com/telemetry",
+                deployment_id_path=tmpdir,
+                service_name="test-svc",
+                environment="test",
+                package_version="0.5.0",
+            )
+            with patch("bh_fastapi_audit._telemetry.urlopen") as mock_urlopen:
+                emitter.record(_make_event())
+                emitter.record(_make_event())
+                mock_urlopen.assert_not_called()
+
+    def test_period_rollover_triggers_emission(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = TelemetryEmitter(
+                endpoint="https://example.com/telemetry",
+                deployment_id_path=tmpdir,
+                service_name="test-svc",
+                environment="test",
+                package_version="0.5.0",
+            )
+            emitter._period_end = datetime.now(UTC) - timedelta(seconds=1)
+
+            with patch("bh_fastapi_audit._telemetry.urlopen") as mock_urlopen:
+                emitter.record(_make_event())
+                mock_urlopen.assert_called_once()
+
+    def test_emission_failure_silently_swallowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = TelemetryEmitter(
+                endpoint="https://example.com/telemetry",
+                deployment_id_path=tmpdir,
+                service_name="test-svc",
+                environment="test",
+                package_version="0.5.0",
+            )
+            emitter._period_end = datetime.now(UTC) - timedelta(seconds=1)
+
+            with patch(
+                "bh_fastapi_audit._telemetry.urlopen", side_effect=Exception("network error")
+            ):
+                emitter.record(_make_event())
+
+    def test_deployment_id_created_and_reused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = TelemetryEmitter(
+                endpoint="https://example.com/telemetry",
+                deployment_id_path=tmpdir,
+                service_name="test-svc",
+                environment="test",
+                package_version="0.5.0",
+            )
+            id1 = emitter._get_or_create_deployment_id()
+            id2 = emitter._get_or_create_deployment_id()
+            assert id1 == id2
+            assert len(id1) == 36
+
+            emitter2 = TelemetryEmitter(
+                endpoint="https://example.com/telemetry",
+                deployment_id_path=tmpdir,
+                service_name="test-svc",
+                environment="test",
+                package_version="0.5.0",
+            )
+            assert emitter2._get_or_create_deployment_id() == id1
+
+    def test_telemetry_disabled_no_emitter(self) -> None:
+        from bh_fastapi_audit.middleware import AuditConfig, AuditMiddleware
+        from bh_fastapi_audit.sinks.base import AuditSink
+
+        class DummySink(AuditSink):
+            def emit(self, event: dict[str, Any]) -> None:
+                pass
+
+        config = AuditConfig(service_name="test", telemetry_enabled=False)
+        mw = AuditMiddleware(app=None, sink=DummySink(), config=config)
+        assert mw._telemetry is None

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1,0 +1,242 @@
+"""Tests for bh_fastapi_audit._verifier."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bh_fastapi_audit._chain import compute_chain_hash
+from bh_fastapi_audit._verifier import VerifyFailure, VerifyResult, verify_chain
+
+
+def _make_event(
+    event_id: str = "evt-001",
+    timestamp: str = "2026-01-01T00:00:00.000Z",
+    action_type: str = "READ",
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.1",
+        "event_id": event_id,
+        "timestamp": timestamp,
+        "service": {"name": "test-svc", "environment": "test"},
+        "actor": {"subject_id": "user-1", "subject_type": "human"},
+        "action": {"type": action_type, "data_classification": "PHI"},
+        "resource": {"type": "Patient"},
+        "outcome": {"status": "SUCCESS"},
+    }
+
+
+def _build_chain(events: list[dict[str, Any]], algorithm: str = "sha256") -> list[dict[str, Any]]:
+    chain: list[dict[str, Any]] = []
+    prev_hash: str | None = None
+    for evt in events:
+        integrity = compute_chain_hash(evt, prev_hash, algorithm)
+        chained = {**evt, "integrity": integrity}
+        prev_hash = integrity["event_hash"]
+        chain.append(chained)
+    return chain
+
+
+class TestVerifyChainPass:
+    def test_intact_chain_three_events(self) -> None:
+        events = [
+            _make_event("e1", "2026-01-01T00:00:00.000Z"),
+            _make_event("e2", "2026-01-01T00:01:00.000Z"),
+            _make_event("e3", "2026-01-01T00:02:00.000Z"),
+        ]
+        chain = _build_chain(events)
+        result = verify_chain(chain)
+
+        assert result.result == "PASS"
+        assert result.events_scanned == 3
+        assert result.chain_length == 3
+        assert result.chain_gaps == 0
+        assert result.hash_mismatches == 0
+        assert result.unchained_events == 0
+        assert result.failures == []
+
+    def test_single_event_no_prev(self) -> None:
+        events = [_make_event()]
+        chain = _build_chain(events)
+        result = verify_chain(chain)
+
+        assert result.result == "PASS"
+        assert result.chain_length == 1
+        assert result.chain_gaps == 0
+
+    def test_empty_input(self) -> None:
+        result = verify_chain([])
+        assert result.result == "PASS"
+        assert result.events_scanned == 0
+        assert result.chain_length == 0
+
+    def test_time_range_captured(self) -> None:
+        events = [
+            _make_event("e1", "2026-01-01T00:00:00.000Z"),
+            _make_event("e2", "2026-01-01T12:00:00.000Z"),
+        ]
+        chain = _build_chain(events)
+        result = verify_chain(chain)
+
+        assert result.time_range_start == "2026-01-01T00:00:00.000Z"
+        assert result.time_range_end == "2026-01-01T12:00:00.000Z"
+
+
+class TestVerifyChainHashMismatch:
+    def test_tampered_event_detected(self) -> None:
+        events = [
+            _make_event("e1", "2026-01-01T00:00:00.000Z"),
+            _make_event("e2", "2026-01-01T00:01:00.000Z"),
+        ]
+        chain = _build_chain(events)
+        chain[1]["action"]["type"] = "DELETE"
+
+        result = verify_chain(chain)
+        assert result.result == "FAIL"
+        assert result.hash_mismatches == 1
+        assert len(result.failures) == 1
+        assert result.failures[0].failure_type == "hash_mismatch"
+        assert result.failures[0].event_id == "e2"
+
+    def test_tampered_first_event(self) -> None:
+        events = [_make_event("e1")]
+        chain = _build_chain(events)
+        chain[0]["outcome"]["status"] = "FAILURE"
+
+        result = verify_chain(chain)
+        assert result.result == "FAIL"
+        assert result.hash_mismatches == 1
+
+    def test_failure_details(self) -> None:
+        events = [_make_event("e1")]
+        chain = _build_chain(events)
+        chain[0]["service"]["name"] = "tampered"
+
+        result = verify_chain(chain)
+        failure = result.failures[0]
+        assert failure.event_index == 0
+        assert failure.expected is not None
+        assert failure.actual is not None
+        assert failure.expected != failure.actual
+        assert "modified" in failure.message.lower()
+
+
+class TestVerifyChainGap:
+    def test_chain_gap_missing_prev(self) -> None:
+        events = [
+            _make_event("e1", "2026-01-01T00:00:00.000Z"),
+            _make_event("e2", "2026-01-01T00:01:00.000Z"),
+            _make_event("e3", "2026-01-01T00:02:00.000Z"),
+        ]
+        chain = _build_chain(events)
+        del chain[2]["integrity"]["prev_event_hash"]
+
+        result = verify_chain(chain)
+        assert result.result == "FAIL"
+        assert result.chain_gaps == 1
+        assert result.failures[0].failure_type == "chain_gap"
+        assert result.failures[0].event_id == "e3"
+
+    def test_chain_gap_wrong_prev(self) -> None:
+        events = [
+            _make_event("e1", "2026-01-01T00:00:00.000Z"),
+            _make_event("e2", "2026-01-01T00:01:00.000Z"),
+        ]
+        chain = _build_chain(events)
+        chain[1]["integrity"]["prev_event_hash"] = "badhash"
+
+        result = verify_chain(chain)
+        assert result.result == "FAIL"
+        assert result.chain_gaps == 1
+        assert "deleted or reordered" in result.failures[0].message.lower()
+
+
+class TestVerifyChainUnchainedEvents:
+    def test_events_without_integrity_counted(self) -> None:
+        events = [
+            _make_event("e1"),
+            _make_event("e2"),
+        ]
+        chain = _build_chain(events[:1])
+        chain.append(events[1])
+
+        result = verify_chain(chain)
+        assert result.unchained_events == 1
+        assert result.chain_length == 1
+        assert result.result == "PASS"
+
+    def test_all_unchained(self) -> None:
+        events = [_make_event("e1"), _make_event("e2")]
+        result = verify_chain(events)
+
+        assert result.unchained_events == 2
+        assert result.chain_length == 0
+        assert result.result == "PASS"
+
+
+class TestVerifyChainMultipleFailures:
+    def test_multiple_failures_reported(self) -> None:
+        events = [
+            _make_event("e1", "2026-01-01T00:00:00.000Z"),
+            _make_event("e2", "2026-01-01T00:01:00.000Z"),
+            _make_event("e3", "2026-01-01T00:02:00.000Z"),
+        ]
+        chain = _build_chain(events)
+        chain[1]["action"]["type"] = "DELETE"
+        chain[2]["action"]["type"] = "DELETE"
+
+        result = verify_chain(chain)
+        assert result.result == "FAIL"
+        assert len(result.failures) >= 2
+
+
+class TestVerifyChainAlgorithms:
+    def test_sha384_chain(self) -> None:
+        events = [
+            _make_event("e1", "2026-01-01T00:00:00.000Z"),
+            _make_event("e2", "2026-01-01T00:01:00.000Z"),
+        ]
+        chain = _build_chain(events, algorithm="sha384")
+        result = verify_chain(chain, algorithm="sha384")
+        assert result.result == "PASS"
+
+    def test_sha512_chain(self) -> None:
+        events = [
+            _make_event("e1", "2026-01-01T00:00:00.000Z"),
+            _make_event("e2", "2026-01-01T00:01:00.000Z"),
+        ]
+        chain = _build_chain(events, algorithm="sha512")
+        result = verify_chain(chain, algorithm="sha512")
+        assert result.result == "PASS"
+
+    def test_algorithm_from_integrity_block(self) -> None:
+        events = [_make_event("e1")]
+        chain = _build_chain(events, algorithm="sha512")
+        result = verify_chain(chain)
+        assert result.result == "PASS"
+
+
+class TestVerifyResultDataclass:
+    def test_dataclass_fields(self) -> None:
+        r = VerifyResult(
+            events_scanned=0,
+            time_range_start=None,
+            time_range_end=None,
+            chain_length=0,
+            chain_gaps=0,
+            hash_mismatches=0,
+            unchained_events=0,
+            result="PASS",
+        )
+        assert r.failures == []
+
+    def test_failure_dataclass_fields(self) -> None:
+        f = VerifyFailure(
+            event_index=0,
+            event_id="test",
+            timestamp="2026-01-01",
+            failure_type="hash_mismatch",
+            expected="abc",
+            actual="def",
+            message="mismatch",
+        )
+        assert f.failure_type == "hash_mismatch"


### PR DESCRIPTION
Release v1.0.0 — production-ready FastAPI audit middleware with integrity verification

- Bump version from 0.5.0 to 1.0.0 across pyproject.toml, __init__.py,
  CHANGELOG, README, and test_public_api
- Fix CLI DynamoDB path: require --service flag, catch OSError, add version
  to human and JSON output
- Fix DynamoDBSink: add end param to query_by_actor and query_denials,
  add _paginated_query and _parse_items (deserialize event_json from GSI
  results), add event_json to all 3 GSI projections so queries return
  usable event dicts
- Fix telemetry accuracy in queue mode: move record()/record_failure()
  from enqueue-time to drain-time in EmitQueue, preventing overcounting
  events that later fail during sink.emit()
- Wire telemetry record_chain_gap() into _safe_emit
- Fix telemetry period window: track _period_start separately
- Simplify _next_sunday (remove redundant midnight check)
- Fix LedgerSink: copy event dict instead of mutating caller's reference,
  add threading.Lock for thread-safe chain hashing
- Switch DynamoDBSink._create_table to PAY_PER_REQUEST billing
- Rewrite docs/storage-patterns.md to match actual DynamoDB schema
- Add missing v1.0 config fields to README configuration table
- Update DynamoDB test assertions from flat attribute access to nested
  event dict access (matching _parse_items behavior)