### PR TITLE
telemetry system rewritten for ephemeral/serverless environments with Dual-trigger flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-04-13
+
+### Changed
+
+- **Lambda-safe telemetry** — telemetry system rewritten for ephemeral/serverless
+  environments.  Dual-trigger flush (interval **or** event threshold, whichever comes
+  first, default 300s / 500 events).  Mid-request flushes use a fire-and-forget daemon
+  thread (zero added latency).  Disk-backed counter persistence survives cold starts.
+  `AuditMiddleware.shutdown()` now flushes telemetry (blocking, bounded by
+  `telemetry_http_timeout_s`).  Failure logging raised from `DEBUG` to configurable
+  `telemetry_log_level` (default `WARNING`).
+- Five new `AuditConfig` fields: `telemetry_flush_interval_seconds`,
+  `telemetry_event_flush_threshold`, `telemetry_log_level`,
+  `telemetry_http_timeout_s`, `telemetry_flush_stale_on_init`.
+- Updated `docs/telemetry.md` with Lambda configuration section and cold-start
+  latency guidance.
+
+### Fixed
+
+- **Telemetry payload format** — telemetry report now uses `"schema": "bh-telemetry-v1"`
+  and nested `"period": {"start": ..., "end": ...}` to match the receiver Lambda API.
+  The v1.0.0 format was silently rejected with HTTP 400; telemetry was never actually
+  delivered.
+
 ## [1.0.0] - 2026-04-04
 
 ### Added
@@ -357,6 +381,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apache 2.0 license
 - Vendored bh-audit-schema v1.0 JSON schema
 
+[1.1.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.2.2...v0.3.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The goal of this library is to make consistent, structured audit trails easy to 
 
 This project is an implementation layer that turns the bh-audit-schema standard into working FastAPI middleware.
 
-**Current version: v1.0.0** — Verifier CLI, opt-in telemetry, chain hashing, DynamoDB sink, runtime validation, DENIED outcome with denial callbacks, schema negotiation.
+**Current version: v1.1.0** — Lambda-safe telemetry, Verifier CLI, chain hashing, DynamoDB sink, runtime validation, DENIED outcome with denial callbacks, schema negotiation.
 
 ### v1.0 (current)
 - **Verifier CLI** — `bh-audit verify` for chain integrity verification (file or DynamoDB source, human or JSON output)
@@ -308,7 +308,12 @@ See [docs/migrating-1.0-to-1.1.md](docs/migrating-1.0-to-1.1.md) for a full migr
 | `hash_algorithm` | `"sha256"` | Hash algorithm for chain hashing (`"sha256"`, `"sha384"`, `"sha512"`) |
 | `telemetry_enabled` | `False` | Enable opt-in anonymous telemetry |
 | `telemetry_endpoint` | `"https://…/v1/report"` | Telemetry receiver URL |
-| `telemetry_deployment_id_path` | `"/tmp/bh-audit/"` | Directory for anonymous deployment ID file |
+| `telemetry_deployment_id_path` | `"/tmp/bh-audit/"` | Directory for deployment ID and state files |
+| `telemetry_flush_interval_seconds` | `300.0` | Flush after this many seconds elapsed |
+| `telemetry_event_flush_threshold` | `500` | Also flush when this many events accumulate |
+| `telemetry_log_level` | `logging.WARNING` | Log level for telemetry emission failures |
+| `telemetry_http_timeout_s` | `1.5` | Max seconds for the telemetry HTTP POST |
+| `telemetry_flush_stale_on_init` | `True` | Flush stale disk state on cold start |
 
 ## PHI-safe defaults
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -19,7 +19,7 @@ config = AuditConfig(
 
 ## What is sent
 
-A single JSON report per deployment, per week (Sunday-to-Sunday):
+A single JSON report per deployment, per flush interval:
 
 ```json
 {
@@ -29,8 +29,8 @@ A single JSON report per deployment, per week (Sunday-to-Sunday):
   "environment": "production",
   "package": "bh-fastapi-audit",
   "package_version": "1.0.0",
-  "period_start": "2026-03-29T00:00:00+00:00",
-  "period_end": "2026-04-05T00:00:00+00:00",
+  "period_start": "2026-04-13T00:00:00+00:00",
+  "period_end": "2026-04-13T00:05:00+00:00",
   "counters": {
     "events_emitted": 12847,
     "by_action_type": {"READ": 8021, "CREATE": 3102, "UPDATE": 1724},
@@ -56,23 +56,94 @@ A single JSON report per deployment, per week (Sunday-to-Sunday):
 
 1. On each request, after the audit event is emitted, counters are incremented
    in-memory (thread-safe).
-2. On each call, the current UTC time is compared to the period boundary.
-3. When the period boundary is crossed, the report is POSTed via `urllib.request`
-   with a 5-second timeout.
-4. Counters are reset after successful emission.
-5. **No background threads** -- this works in Lambda and single-process environments.
+2. A flush triggers when **either** `telemetry_flush_interval_seconds` (default 300s)
+   has elapsed **or** `telemetry_event_flush_threshold` (default 500) events have
+   accumulated — whichever comes first.
+3. Mid-request flushes use a **fire-and-forget daemon thread** so `record()` adds
+   zero latency to the request path.  Only one flush runs at a time (protected by a
+   lock; concurrent triggers are skipped).
+4. Counters are checkpointed to disk every `max(50, threshold // 10)` events so data
+   survives process restarts.
+5. On success, counters are reset and the disk state is cleared. On failure, the
+   snapshot is persisted to disk for recovery on the next cold start.
+6. `AuditMiddleware.shutdown()` calls `flush()` (blocking, bounded by
+   `telemetry_http_timeout_s`) to guarantee a delivery attempt before the process exits.
+
+## Configuration fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `telemetry_enabled` | `bool` | `False` | Master switch — nothing is sent or written when `False` |
+| `telemetry_endpoint` | `str` | `"https://…/v1/report"` | Telemetry receiver URL |
+| `telemetry_deployment_id_path` | `str` | `"/tmp/bh-audit/"` | Directory for deployment ID and state files |
+| `telemetry_flush_interval_seconds` | `float` | `300.0` | Flush after this many seconds elapsed |
+| `telemetry_event_flush_threshold` | `int` | `500` | Also flush when this many events accumulate |
+| `telemetry_log_level` | `int` | `logging.WARNING` | Log level for emission failures |
+| `telemetry_http_timeout_s` | `float` | `1.5` | Max seconds for the HTTP POST |
+| `telemetry_flush_stale_on_init` | `bool` | `True` | Flush stale disk state on cold start (see below) |
+
+## Lambda / serverless configuration
+
+The default settings work on Lambda and ephemeral infrastructure.  The dual-trigger
+flush (time + event count) and disk-backed persistence solve the fundamental problem
+of short-lived processes that never survive a weekly boundary.
+
+### Recommended Lambda setup
+
+```python
+config = AuditConfig(
+    service_name="intake-api",
+    telemetry_enabled=True,
+    # Defaults are Lambda-friendly:
+    # telemetry_flush_interval_seconds=300.0,  # 5 minutes
+    # telemetry_event_flush_threshold=500,
+    # telemetry_http_timeout_s=1.5,
+    # telemetry_flush_stale_on_init=True,
+)
+```
+
+### Cold-start latency penalty
+
+When `telemetry_flush_stale_on_init=True` (default), a cold start that finds a
+stale state file from a previous container will perform a **blocking** HTTP POST
+(bounded by `telemetry_http_timeout_s`, default 1.5s) in `__init__`.  This recovers
+data from the previous container's counters.
+
+If cold-start latency is more important than recovering stale telemetry, set
+`telemetry_flush_stale_on_init=False` — the stale data will be discarded.
+
+### Shutdown handler
+
+Wire `AuditMiddleware.shutdown()` into your ASGI lifespan for a final flush:
+
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    await audit_middleware.shutdown()  # drains queue + flushes telemetry
+```
+
+## Disk state
+
+Two files are written to `telemetry_deployment_id_path` (default `/tmp/bh-audit/`):
+
+- `.bh-audit-deployment-id` — anonymous UUID, persisted across restarts
+- `.bh-audit-telemetry-state.json` — counter checkpoint with `state_schema_version: 1`
+
+Both are created only when `telemetry_enabled=True`.  When `telemetry_enabled=False`,
+no files are read or written.
 
 ## Deployment ID
 
 An anonymous UUID is generated on first run and persisted to
 `<telemetry_deployment_id_path>/.bh-audit-deployment-id`. This allows correlating
-weekly reports from the same deployment without identifying the operator.
+reports from the same deployment without identifying the operator.
 
 ## Failure behaviour
 
 If the HTTP POST fails (network error, timeout, non-200 response), the failure is
-silently swallowed. A `DEBUG`-level log message is emitted to the `bh.audit.telemetry`
-logger. Counters are **not** reset on failure, so the data rolls into the next period.
+logged at `telemetry_log_level` (default `WARNING`).  The counter snapshot is
+persisted to disk for recovery on the next cold start.
 
 Telemetry never raises exceptions and never affects application behaviour.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bh-fastapi-audit"
-version = "1.0.0"
+version = "1.1.0"
 description = "FastAPI ASGI middleware for emitting PHI-safe audit events for behavioral healthcare systems"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/bh_fastapi_audit/__init__.py
+++ b/src/bh_fastapi_audit/__init__.py
@@ -5,7 +5,7 @@ This package provides pure ASGI middleware for emitting structured audit events
 conforming to the bh-audit-schema v1.1 standard for behavioral healthcare systems.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 from bh_fastapi_audit._chain import canonical_serialize, compute_chain_hash
 from bh_fastapi_audit._chain_state import ChainState

--- a/src/bh_fastapi_audit/_telemetry.py
+++ b/src/bh_fastapi_audit/_telemetry.py
@@ -2,8 +2,10 @@
 Opt-in, privacy-first telemetry emitter.
 
 Collects **counter-based aggregate statistics only** -- no PII, no PHI,
-no event content, no IP addresses.  Designed for Lambda-friendly
-environments (no background threads).
+no event content, no IP addresses.  Lambda-safe: dual-trigger flush
+(interval **or** event threshold), fire-and-forget daemon threads for
+mid-request flushes, disk-backed persistence across cold starts, and
+bounded-timeout blocking flush on shutdown.
 
 Off by default.  Enable via ``AuditConfig(telemetry_enabled=True)``.
 """
@@ -17,14 +19,21 @@ import threading
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 _log = logging.getLogger("bh.audit.telemetry")
 
 _TELEMETRY_SCHEMA_VERSION = "1.0"
-_DEFAULT_PERIOD_DAYS = 7  # Sunday-to-Sunday windows
-_HTTP_TIMEOUT_S = 5
 _DEPLOYMENT_ID_FILE = ".bh-audit-deployment-id"
+_COUNTER_STATE_FILE = ".bh-audit-telemetry-state.json"
+_STATE_SCHEMA_VERSION = 1
+
+_DEFAULT_FLUSH_INTERVAL_S = 300.0
+_DEFAULT_EVENT_THRESHOLD = 500
+_DEFAULT_HTTP_TIMEOUT_S = 1.5
+
+_NETWORK_ERRORS = (OSError, URLError, TimeoutError, ValueError)
 
 
 class TelemetryCounters:
@@ -51,8 +60,8 @@ class TelemetryCounters:
         self.chain_gaps: int = 0
         self.emit_failures: int = 0
 
-    def increment(self, event: dict[str, Any]) -> None:
-        """Tally a single event (thread-safe)."""
+    def increment(self, event: dict[str, Any]) -> int:
+        """Tally a single event (thread-safe).  Returns post-increment count."""
         action_type = event.get("action", {}).get("type", "UNKNOWN")
         outcome = event.get("outcome", {}).get("status", "UNKNOWN")
         classification = event.get("action", {}).get("data_classification", "UNKNOWN")
@@ -67,6 +76,7 @@ class TelemetryCounters:
             )
             if has_integrity:
                 self.integrity_events += 1
+            return self.events_emitted
 
     def increment_failure(self) -> None:
         """Record a single emit failure (thread-safe)."""
@@ -78,6 +88,46 @@ class TelemetryCounters:
         with self._lock:
             self.chain_gaps += 1
 
+    def to_dict(self) -> dict[str, Any]:
+        """Snapshot counter values to a plain dict (for disk persistence)."""
+        with self._lock:
+            return {
+                "events_emitted": self.events_emitted,
+                "by_action_type": dict(self.by_action_type),
+                "by_outcome": dict(self.by_outcome),
+                "by_data_classification": dict(self.by_data_classification),
+                "integrity_events": self.integrity_events,
+                "chain_gaps": self.chain_gaps,
+                "emit_failures": self.emit_failures,
+            }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TelemetryCounters:
+        """Restore counters from a serialised dict."""
+        c = cls()
+        c.events_emitted = data.get("events_emitted", 0)
+        c.by_action_type = dict(data.get("by_action_type", {}))
+        c.by_outcome = dict(data.get("by_outcome", {}))
+        c.by_data_classification = dict(data.get("by_data_classification", {}))
+        c.integrity_events = data.get("integrity_events", 0)
+        c.chain_gaps = data.get("chain_gaps", 0)
+        c.emit_failures = data.get("emit_failures", 0)
+        return c
+
+    def merge(self, other_dict: dict[str, Any]) -> None:
+        """Add values from *other_dict* into self (thread-safe)."""
+        with self._lock:
+            self.events_emitted += other_dict.get("events_emitted", 0)
+            for k, v in other_dict.get("by_action_type", {}).items():
+                self.by_action_type[k] = self.by_action_type.get(k, 0) + v
+            for k, v in other_dict.get("by_outcome", {}).items():
+                self.by_outcome[k] = self.by_outcome.get(k, 0) + v
+            for k, v in other_dict.get("by_data_classification", {}).items():
+                self.by_data_classification[k] = self.by_data_classification.get(k, 0) + v
+            self.integrity_events += other_dict.get("integrity_events", 0)
+            self.chain_gaps += other_dict.get("chain_gaps", 0)
+            self.emit_failures += other_dict.get("emit_failures", 0)
+
     def to_report(
         self,
         deployment_id: str,
@@ -85,7 +135,7 @@ class TelemetryCounters:
         environment: str,
         package_version: str,
     ) -> dict[str, Any]:
-        """Snapshot counters into a telemetry report payload."""
+        """Snapshot counters into a telemetry report dict (for inspection/tests)."""
         with self._lock:
             return {
                 "schema_version": _TELEMETRY_SCHEMA_VERSION,
@@ -94,8 +144,6 @@ class TelemetryCounters:
                 "environment": environment,
                 "package": "bh-fastapi-audit",
                 "package_version": package_version,
-                "period_start": None,
-                "period_end": None,
                 "counters": {
                     "events_emitted": self.events_emitted,
                     "by_action_type": dict(self.by_action_type),
@@ -119,19 +167,17 @@ class TelemetryCounters:
             self.emit_failures = 0
 
 
-def _next_sunday(dt: datetime) -> datetime:
-    """Return the start of the next Sunday (UTC midnight) after *dt*."""
-    days_until_sunday = (6 - dt.weekday()) % 7
-    target = dt.date() + timedelta(days=days_until_sunday or 7)
-    return datetime(target.year, target.month, target.day, tzinfo=UTC)
-
-
 class TelemetryEmitter:
-    """Counter-based period-check emitter.
+    """Lambda-safe telemetry emitter with dual-trigger flush.
 
-    On each ``record()`` call, counters are incremented and the period
-    boundary is checked.  If the period has elapsed, the report is
-    POSTed via urllib and counters are reset.  No background threads.
+    Flushes when *either* ``flush_interval_seconds`` has elapsed *or*
+    ``event_flush_threshold`` events have accumulated — whichever comes
+    first.
+
+    Mid-request flushes use a fire-and-forget daemon thread so
+    ``record()`` never blocks the caller.  ``flush()`` is synchronous
+    (bounded by ``http_timeout_s``) and intended for shutdown handlers.
+    Only one flush runs at a time via ``_flush_lock``.
     """
 
     def __init__(
@@ -141,28 +187,47 @@ class TelemetryEmitter:
         service_name: str,
         environment: str,
         package_version: str,
+        flush_interval_seconds: float = _DEFAULT_FLUSH_INTERVAL_S,
+        event_flush_threshold: int = _DEFAULT_EVENT_THRESHOLD,
+        log_level: int = logging.WARNING,
+        http_timeout_s: float = _DEFAULT_HTTP_TIMEOUT_S,
+        flush_stale_on_init: bool = True,
     ) -> None:
         self._endpoint = endpoint
         self._deployment_id_path = deployment_id_path
         self._service_name = service_name
         self._environment = environment
         self._package_version = package_version
+        self._flush_interval_seconds = flush_interval_seconds
+        self._event_flush_threshold = event_flush_threshold
+        self._log_level = log_level
+        self._http_timeout_s = http_timeout_s
+        self._flush_stale_on_init = flush_stale_on_init
+
         self._counters = TelemetryCounters()
         self._deployment_id: str | None = None
+        self._flush_lock = threading.Lock()
+        self._checkpoint_every = max(50, event_flush_threshold // 10)
+
         now = datetime.now(UTC)
         self._period_start = now
-        self._period_end = _next_sunday(now)
+        self._period_end = now + timedelta(seconds=flush_interval_seconds)
+
+        self._load_state()
 
     @property
     def counters(self) -> TelemetryCounters:
         return self._counters
 
     def record(self, event: dict[str, Any]) -> None:
-        """Increment counters and emit if period boundary crossed."""
-        self._counters.increment(event)
-        now = datetime.now(UTC)
-        if now >= self._period_end:
-            self._emit_report(now)
+        """Increment counters; fire async flush if trigger condition met."""
+        count = self._counters.increment(event)
+        threshold_hit = count >= self._event_flush_threshold
+        interval_elapsed = datetime.now(UTC) >= self._period_end
+        if interval_elapsed or threshold_hit:
+            self._fire_async(datetime.now(UTC))
+        elif count % self._checkpoint_every == 0:
+            self._save_state()
 
     def record_failure(self) -> None:
         """Record an emit failure."""
@@ -172,18 +237,53 @@ class TelemetryEmitter:
         """Record a chain gap."""
         self._counters.increment_chain_gap()
 
+    def flush(self) -> None:
+        """Blocking flush bounded by ``http_timeout_s``.
+
+        Guarantees a delivery attempt.  Intended for shutdown handlers
+        (``AuditMiddleware.shutdown()``) — **not** for mid-request use.
+        """
+        with self._flush_lock:
+            if self._counters.events_emitted == 0:
+                return
+            self._emit_report(datetime.now(UTC))
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _fire_async(self, now: datetime) -> None:
+        """Best-effort background flush.  One in-flight flush at a time."""
+        if not self._flush_lock.acquire(blocking=False):
+            return
+
+        def _run() -> None:
+            try:
+                self._emit_report(now)
+            finally:
+                self._flush_lock.release()
+
+        threading.Thread(target=_run, daemon=True).start()
+
     def _emit_report(self, now: datetime) -> None:
-        """POST the telemetry report. Failures are silently swallowed."""
+        """POST a telemetry report.  Snapshot-first so failures preserve data."""
+        snapshot = self._counters.to_dict()
         try:
             deployment_id = self._get_or_create_deployment_id()
-            report = self._counters.to_report(
-                deployment_id=deployment_id,
-                service_name=self._service_name,
-                environment=self._environment,
-                package_version=self._package_version,
-            )
-            report["period_start"] = self._period_start.isoformat()
-            report["period_end"] = self._period_end.isoformat()
+            report = {
+                "schema": "bh-telemetry-v1",
+                "schema_version": _TELEMETRY_SCHEMA_VERSION,
+                "deployment_id": deployment_id,
+                "service_name": self._service_name,
+                "environment": self._environment,
+                "package": "bh-fastapi-audit",
+                "package_version": self._package_version,
+                "period": {
+                    "start": self._period_start.isoformat(),
+                    "end": now.isoformat(),
+                },
+                "counters": snapshot,
+            }
 
             body = json.dumps(report).encode("utf-8")
             req = Request(
@@ -192,13 +292,111 @@ class TelemetryEmitter:
                 headers={"Content-Type": "application/json"},
                 method="POST",
             )
-            urlopen(req, timeout=_HTTP_TIMEOUT_S)  # noqa: S310
+            with urlopen(req, timeout=self._http_timeout_s) as resp:  # noqa: S310
+                if resp.status < 200 or resp.status >= 300:
+                    raise OSError(f"Telemetry endpoint returned HTTP {resp.status}")
             self._counters.reset()
+            self._clear_state()
             self._period_start = now
-        except Exception:
-            _log.debug("Telemetry emission failed (silently swallowed)", exc_info=True)
+        except _NETWORK_ERRORS as exc:
+            self._save_state(snapshot)
+            _log.log(
+                self._log_level,
+                "Telemetry emission failed: %s",
+                type(exc).__name__,
+            )
         finally:
-            self._period_end = _next_sunday(now)
+            self._period_end = now + timedelta(seconds=self._flush_interval_seconds)
+
+    # ------------------------------------------------------------------
+    # Disk persistence
+    # ------------------------------------------------------------------
+
+    def _state_file_path(self) -> str:
+        return os.path.join(self._deployment_id_path, _COUNTER_STATE_FILE)
+
+    def _save_state(self, snapshot: dict[str, Any] | None = None) -> None:
+        """Persist counters to disk so the next cold start can recover."""
+        with self._flush_lock if snapshot is None else _nullcontext():
+            if snapshot is None:
+                snapshot = self._counters.to_dict()
+            period_start = self._period_start.isoformat()
+            period_end = self._period_end.isoformat()
+        state = {
+            "state_schema_version": _STATE_SCHEMA_VERSION,
+            "period_start": period_start,
+            "period_end": period_end,
+            "counters": snapshot,
+        }
+        try:
+            os.makedirs(self._deployment_id_path, exist_ok=True)
+            with open(self._state_file_path(), "w", encoding="utf-8") as fh:
+                json.dump(state, fh)
+        except OSError:
+            _log.log(self._log_level, "Could not save telemetry state to disk")
+
+    def _load_state(self) -> None:
+        """Restore counters from disk on cold start; flush stale data if configured."""
+        try:
+            with open(self._state_file_path(), encoding="utf-8") as fh:
+                state = json.load(fh)
+        except (OSError, json.JSONDecodeError, ValueError):
+            return
+
+        if not isinstance(state, dict):
+            self._clear_state()
+            return
+
+        counters_dict = state.get("counters")
+        if not isinstance(counters_dict, dict) or counters_dict.get("events_emitted", 0) == 0:
+            self._clear_state()
+            return
+
+        period_end_str = state.get("period_end")
+        period_start_str = state.get("period_start")
+
+        if period_start_str:
+            try:
+                self._period_start = datetime.fromisoformat(period_start_str)
+            except (ValueError, TypeError):
+                pass
+
+        stale = False
+        if period_end_str:
+            try:
+                stored_end = datetime.fromisoformat(period_end_str)
+                if datetime.now(UTC) >= stored_end:
+                    stale = True
+            except (ValueError, TypeError):
+                pass
+
+        if stale and self._flush_stale_on_init:
+            with self._flush_lock:
+                try:
+                    self._counters.merge(counters_dict)
+                except Exception:
+                    self._clear_state()
+                    return
+                if self._counters.events_emitted > 0:
+                    self._emit_report(datetime.now(UTC))
+        elif stale:
+            self._clear_state()
+        else:
+            try:
+                self._counters.merge(counters_dict)
+            except Exception:
+                self._clear_state()
+
+    def _clear_state(self) -> None:
+        """Remove the disk state file."""
+        try:
+            os.remove(self._state_file_path())
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Deployment ID
+    # ------------------------------------------------------------------
 
     def _get_or_create_deployment_id(self) -> str:
         """Read or create an anonymous deployment UUID."""
@@ -227,3 +425,13 @@ class TelemetryEmitter:
 
         self._deployment_id = new_id
         return new_id
+
+
+class _nullcontext:
+    """Minimal no-op context manager (avoid importing contextlib)."""
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(self, *_: object) -> None:
+        pass

--- a/src/bh_fastapi_audit/middleware.py
+++ b/src/bh_fastapi_audit/middleware.py
@@ -98,6 +98,11 @@ class AuditConfig:
     telemetry_enabled: bool = False
     telemetry_endpoint: str = "https://abt0rxi196.execute-api.us-east-1.amazonaws.com/v1/report"
     telemetry_deployment_id_path: str = "/tmp/bh-audit/"
+    telemetry_flush_interval_seconds: float = 300.0
+    telemetry_event_flush_threshold: int = 500
+    telemetry_log_level: int = logging.WARNING
+    telemetry_http_timeout_s: float = 1.5
+    telemetry_flush_stale_on_init: bool = True
 
     def __post_init__(self) -> None:
         if isinstance(self.metadata_allowlist, set):
@@ -142,6 +147,11 @@ class AuditMiddleware:
                 service_name=config.service_name,
                 environment=config.service_environment,
                 package_version=__version__,
+                flush_interval_seconds=config.telemetry_flush_interval_seconds,
+                event_flush_threshold=config.telemetry_event_flush_threshold,
+                log_level=config.telemetry_log_level,
+                http_timeout_s=config.telemetry_http_timeout_s,
+                flush_stale_on_init=config.telemetry_flush_stale_on_init,
             )
         else:
             self._telemetry = None
@@ -163,9 +173,11 @@ class AuditMiddleware:
         return self._stats
 
     async def shutdown(self) -> None:
-        """Drain the async emit queue (call on app shutdown)."""
+        """Drain the async emit queue and flush telemetry (call on app shutdown)."""
         if self._queue is not None:
             await self._queue.shutdown(timeout=self.config.queue_drain_timeout)
+        if self._telemetry is not None:
+            self._telemetry.flush()
 
     # ------------------------------------------------------------------
     # ASGI entry point

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -129,7 +129,7 @@ def test_version_exposed():
     from bh_fastapi_audit import __version__
 
     assert isinstance(__version__, str)
-    assert __version__ == "1.0.0"
+    assert __version__ == "1.1.0"
 
 
 def test_all_exports_defined():

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -3,17 +3,29 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 import tempfile
 import threading
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from bh_fastapi_audit._telemetry import (
+    _COUNTER_STATE_FILE,
+    _STATE_SCHEMA_VERSION,
     TelemetryCounters,
     TelemetryEmitter,
-    _next_sunday,
 )
+
+
+def _mock_urlopen_ok():
+    """Return a patch for urlopen that simulates HTTP 200."""
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return patch("bh_fastapi_audit._telemetry.urlopen", return_value=mock_resp)
 
 
 def _make_event(
@@ -31,6 +43,23 @@ def _make_event(
     return event
 
 
+def _make_emitter(tmpdir: str, **overrides: Any) -> TelemetryEmitter:
+    defaults = {
+        "endpoint": "https://example.com/telemetry",
+        "deployment_id_path": tmpdir,
+        "service_name": "test-svc",
+        "environment": "test",
+        "package_version": "1.0.0",
+    }
+    defaults.update(overrides)
+    return TelemetryEmitter(**defaults)
+
+
+# ======================================================================
+# TelemetryCounters
+# ======================================================================
+
+
 class TestTelemetryCounters:
     def test_increment_tallies_by_action_type(self) -> None:
         c = TelemetryCounters()
@@ -39,6 +68,12 @@ class TestTelemetryCounters:
         c.increment(_make_event(action_type="CREATE"))
         assert c.by_action_type == {"READ": 2, "CREATE": 1}
         assert c.events_emitted == 3
+
+    def test_increment_returns_post_count(self) -> None:
+        c = TelemetryCounters()
+        assert c.increment(_make_event()) == 1
+        assert c.increment(_make_event()) == 2
+        assert c.increment(_make_event()) == 3
 
     def test_increment_tallies_by_outcome(self) -> None:
         c = TelemetryCounters()
@@ -91,6 +126,8 @@ class TestTelemetryCounters:
         assert report["environment"] == "staging"
         assert report["package"] == "bh-fastapi-audit"
         assert report["package_version"] == "1.0.0"
+        assert "period_start" not in report
+        assert "period_end" not in report
         assert "counters" in report
         counters = report["counters"]
         assert counters["events_emitted"] == 1
@@ -124,88 +161,52 @@ class TestTelemetryCounters:
         assert not errors
         assert c.events_emitted == 1000
 
+    def test_to_dict_round_trips(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event(action_type="READ"))
+        c.increment(_make_event(action_type="CREATE", outcome="FAILURE"))
+        c.increment_failure()
+        c.increment_chain_gap()
+        d = c.to_dict()
 
-class TestNextSunday:
-    def test_monday_to_sunday(self) -> None:
-        monday = datetime(2026, 3, 30, 10, 0, tzinfo=UTC)
-        sunday = _next_sunday(monday)
-        assert sunday.weekday() == 6
-        assert sunday > monday
+        c2 = TelemetryCounters.from_dict(d)
+        assert c2.events_emitted == 2
+        assert c2.by_action_type == {"READ": 1, "CREATE": 1}
+        assert c2.by_outcome == {"SUCCESS": 1, "FAILURE": 1}
+        assert c2.emit_failures == 1
+        assert c2.chain_gaps == 1
 
-    def test_sunday_midnight_advances_week(self) -> None:
-        sunday = datetime(2026, 4, 5, 0, 0, tzinfo=UTC)
-        next_sun = _next_sunday(sunday)
-        assert next_sun > sunday
-        assert next_sun.weekday() == 6
+    def test_merge_adds_values(self) -> None:
+        c = TelemetryCounters()
+        c.increment(_make_event(action_type="READ"))
+        c.merge({"events_emitted": 5, "by_action_type": {"READ": 3, "CREATE": 2}})
+        assert c.events_emitted == 6
+        assert c.by_action_type == {"READ": 4, "CREATE": 2}
+
+
+# ======================================================================
+# TelemetryEmitter — basic
+# ======================================================================
 
 
 class TestTelemetryEmitter:
     def test_record_does_not_emit_mid_period(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            emitter = TelemetryEmitter(
-                endpoint="https://example.com/telemetry",
-                deployment_id_path=tmpdir,
-                service_name="test-svc",
-                environment="test",
-                package_version="1.0.0",
-            )
-            with patch("bh_fastapi_audit._telemetry.urlopen") as mock_urlopen:
+            emitter = _make_emitter(tmpdir)
+            with _mock_urlopen_ok() as mock_urlopen:
                 emitter.record(_make_event())
                 emitter.record(_make_event())
                 mock_urlopen.assert_not_called()
 
-    def test_period_rollover_triggers_emission(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            emitter = TelemetryEmitter(
-                endpoint="https://example.com/telemetry",
-                deployment_id_path=tmpdir,
-                service_name="test-svc",
-                environment="test",
-                package_version="1.0.0",
-            )
-            emitter._period_end = datetime.now(UTC) - timedelta(seconds=1)
-
-            with patch("bh_fastapi_audit._telemetry.urlopen") as mock_urlopen:
-                emitter.record(_make_event())
-                mock_urlopen.assert_called_once()
-
-    def test_emission_failure_silently_swallowed(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            emitter = TelemetryEmitter(
-                endpoint="https://example.com/telemetry",
-                deployment_id_path=tmpdir,
-                service_name="test-svc",
-                environment="test",
-                package_version="1.0.0",
-            )
-            emitter._period_end = datetime.now(UTC) - timedelta(seconds=1)
-
-            with patch(
-                "bh_fastapi_audit._telemetry.urlopen", side_effect=Exception("network error")
-            ):
-                emitter.record(_make_event())
-
     def test_deployment_id_created_and_reused(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            emitter = TelemetryEmitter(
-                endpoint="https://example.com/telemetry",
-                deployment_id_path=tmpdir,
-                service_name="test-svc",
-                environment="test",
-                package_version="1.0.0",
-            )
+            emitter = _make_emitter(tmpdir)
             id1 = emitter._get_or_create_deployment_id()
             id2 = emitter._get_or_create_deployment_id()
             assert id1 == id2
             assert len(id1) == 36
 
-            emitter2 = TelemetryEmitter(
-                endpoint="https://example.com/telemetry",
-                deployment_id_path=tmpdir,
-                service_name="test-svc",
-                environment="test",
-                package_version="1.0.0",
-            )
+            emitter2 = _make_emitter(tmpdir)
             assert emitter2._get_or_create_deployment_id() == id1
 
     def test_telemetry_disabled_no_emitter(self) -> None:
@@ -219,3 +220,398 @@ class TestTelemetryEmitter:
         config = AuditConfig(service_name="test", telemetry_enabled=False)
         mw = AuditMiddleware(app=None, sink=DummySink(), config=config)
         assert mw._telemetry is None
+
+
+# ======================================================================
+# flush()
+# ======================================================================
+
+
+class TestFlush:
+    def test_flush_sends_mid_period(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            emitter._counters.increment(_make_event())
+            with _mock_urlopen_ok() as mock_urlopen:
+                emitter.flush()
+                mock_urlopen.assert_called_once()
+
+    def test_flush_noop_on_empty_counters(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            with _mock_urlopen_ok() as mock_urlopen:
+                emitter.flush()
+                mock_urlopen.assert_not_called()
+
+    def test_emission_failure_swallowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            emitter._counters.increment(_make_event())
+            with patch(
+                "bh_fastapi_audit._telemetry.urlopen",
+                side_effect=OSError("network error"),
+            ):
+                emitter.flush()
+
+    def test_flush_waits_for_inflight_async(self) -> None:
+        """flush() acquires _flush_lock, so it waits for any in-flight async flush."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            emitter._counters.increment(_make_event())
+            call_order: list[str] = []
+
+            original_emit = emitter._emit_report
+
+            def slow_emit(now: datetime) -> None:
+                call_order.append("async_start")
+                original_emit(now)
+                call_order.append("async_end")
+
+            emitter._emit_report = slow_emit  # type: ignore[assignment]
+
+            with _mock_urlopen_ok():
+                emitter._fire_async(datetime.now(UTC))
+                emitter._flush_lock.acquire()
+                emitter._flush_lock.release()
+
+            assert "async_start" in call_order
+            assert "async_end" in call_order
+
+
+# ======================================================================
+# Dual-trigger: event threshold and interval
+# ======================================================================
+
+
+class TestDualTrigger:
+    def test_event_threshold_triggers_async_emit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir, event_flush_threshold=5)
+            with patch("bh_fastapi_audit._telemetry.threading.Thread") as mock_thread_cls:
+                mock_thread = MagicMock()
+                mock_thread_cls.return_value = mock_thread
+                for _ in range(4):
+                    emitter._counters.increment(_make_event())
+                emitter.record(_make_event())
+                mock_thread_cls.assert_called_once()
+                _, kwargs = mock_thread_cls.call_args
+                assert kwargs["daemon"] is True
+                mock_thread.start.assert_called_once()
+
+    def test_interval_triggers_async_emit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir, flush_interval_seconds=1.0)
+            emitter._period_end = datetime.now(UTC) - timedelta(seconds=1)
+            with patch("bh_fastapi_audit._telemetry.threading.Thread") as mock_thread_cls:
+                mock_thread = MagicMock()
+                mock_thread_cls.return_value = mock_thread
+                emitter.record(_make_event())
+                mock_thread_cls.assert_called_once()
+                _, kwargs = mock_thread_cls.call_args
+                assert kwargs["daemon"] is True
+
+    def test_flush_interval_respected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir, flush_interval_seconds=10.0)
+            with patch("bh_fastapi_audit._telemetry.threading.Thread") as mock_thread_cls:
+                emitter.record(_make_event())
+                mock_thread_cls.assert_not_called()
+
+
+# ======================================================================
+# Flush lock
+# ======================================================================
+
+
+class TestFlushLock:
+    def test_flush_lock_skip_when_already_held(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            emitter._flush_lock.acquire()
+            try:
+                with patch("bh_fastapi_audit._telemetry.threading.Thread") as mock_thread_cls:
+                    emitter._fire_async(datetime.now(UTC))
+                    mock_thread_cls.assert_not_called()
+            finally:
+                emitter._flush_lock.release()
+
+    def test_concurrent_triggers_only_one_flush(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir, event_flush_threshold=10)
+            call_count = 0
+            original_emit = emitter._emit_report
+
+            def counting_emit(now: datetime) -> None:
+                nonlocal call_count
+                call_count += 1
+                original_emit(now)
+
+            emitter._emit_report = counting_emit  # type: ignore[assignment]
+            barrier = threading.Barrier(5)
+
+            def fire() -> None:
+                barrier.wait()
+                emitter._fire_async(datetime.now(UTC))
+
+            with _mock_urlopen_ok():
+                threads = [threading.Thread(target=fire) for _ in range(5)]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join(timeout=5)
+
+            emitter._flush_lock.acquire()
+            emitter._flush_lock.release()
+
+            assert call_count == 1
+
+
+# ======================================================================
+# Snapshot-first emit ordering
+# ======================================================================
+
+
+class TestSnapshotOrdering:
+    def test_snapshot_taken_before_post(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            emitter._counters.increment(_make_event(action_type="READ"))
+            emitter._counters.increment(_make_event(action_type="CREATE"))
+
+            with patch(
+                "bh_fastapi_audit._telemetry.urlopen",
+                side_effect=OSError("fail"),
+            ):
+                emitter.flush()
+
+            state_path = os.path.join(tmpdir, _COUNTER_STATE_FILE)
+            assert os.path.exists(state_path)
+            with open(state_path) as f:
+                state = json.load(f)
+            assert state["counters"]["events_emitted"] == 2
+            assert state["counters"]["by_action_type"] == {"READ": 1, "CREATE": 1}
+
+
+# ======================================================================
+# Disk persistence
+# ======================================================================
+
+
+class TestDiskPersistence:
+    def test_disk_state_saved_on_flush_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            emitter._counters.increment(_make_event())
+            with patch(
+                "bh_fastapi_audit._telemetry.urlopen",
+                side_effect=OSError("fail"),
+            ):
+                emitter.flush()
+            assert os.path.exists(os.path.join(tmpdir, _COUNTER_STATE_FILE))
+
+    def test_disk_state_restored_on_reinit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            for _ in range(3):
+                emitter._counters.increment(_make_event())
+            emitter._save_state()
+
+            emitter2 = _make_emitter(tmpdir)
+            assert emitter2._counters.events_emitted == 3
+
+    def test_disk_state_schema_version_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            emitter._counters.increment(_make_event())
+            emitter._save_state()
+            state_path = os.path.join(tmpdir, _COUNTER_STATE_FILE)
+            with open(state_path) as f:
+                state = json.load(f)
+            assert state["state_schema_version"] == _STATE_SCHEMA_VERSION
+
+    def test_checkpoint_cadence_scales_with_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            e1 = _make_emitter(tmpdir, event_flush_threshold=500)
+            assert e1._checkpoint_every == 50
+
+            e2 = _make_emitter(tmpdir, event_flush_threshold=50)
+            assert e2._checkpoint_every == 50
+
+            e3 = _make_emitter(tmpdir, event_flush_threshold=5000)
+            assert e3._checkpoint_every == 500
+
+    def test_checkpoint_written_periodically(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir, event_flush_threshold=10000)
+            state_path = os.path.join(tmpdir, _COUNTER_STATE_FILE)
+
+            with _mock_urlopen_ok():
+                for _i in range(1, emitter._checkpoint_every + 1):
+                    emitter.record(_make_event())
+
+            assert os.path.exists(state_path)
+
+    def test_clear_state_removes_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir)
+            emitter._counters.increment(_make_event())
+            emitter._save_state()
+            state_path = os.path.join(tmpdir, _COUNTER_STATE_FILE)
+            assert os.path.exists(state_path)
+            emitter._clear_state()
+            assert not os.path.exists(state_path)
+
+    def test_malformed_state_file_handled(self) -> None:
+        """M4: valid JSON with wrong types should not crash __init__."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = os.path.join(tmpdir, _COUNTER_STATE_FILE)
+            os.makedirs(tmpdir, exist_ok=True)
+            with open(state_path, "w") as f:
+                json.dump({"counters": "garbage", "state_schema_version": 1}, f)
+            emitter = _make_emitter(tmpdir)
+            assert emitter._counters.events_emitted == 0
+
+
+# ======================================================================
+# Stale-period recovery on init
+# ======================================================================
+
+
+class TestStalePeriodRecovery:
+    def _write_stale_state(self, tmpdir: str, events: int = 10) -> None:
+        state = {
+            "state_schema_version": _STATE_SCHEMA_VERSION,
+            "period_start": (datetime.now(UTC) - timedelta(hours=2)).isoformat(),
+            "period_end": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+            "counters": {
+                "events_emitted": events,
+                "by_action_type": {"READ": events},
+                "by_outcome": {"SUCCESS": events},
+                "by_data_classification": {"PHI": events},
+                "integrity_events": 0,
+                "chain_gaps": 0,
+                "emit_failures": 0,
+            },
+        }
+        os.makedirs(tmpdir, exist_ok=True)
+        with open(os.path.join(tmpdir, _COUNTER_STATE_FILE), "w") as f:
+            json.dump(state, f)
+
+    def test_stale_period_flushed_on_init_when_enabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_stale_state(tmpdir)
+            with _mock_urlopen_ok() as mock_urlopen:
+                _make_emitter(tmpdir, flush_stale_on_init=True)
+                mock_urlopen.assert_called_once()
+
+    def test_stale_period_not_flushed_on_init_when_disabled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_stale_state(tmpdir)
+            with _mock_urlopen_ok() as mock_urlopen:
+                emitter = _make_emitter(tmpdir, flush_stale_on_init=False)
+                mock_urlopen.assert_not_called()
+            assert emitter._counters.events_emitted == 0
+
+    def test_telemetry_disabled_no_disk_read(self) -> None:
+        from bh_fastapi_audit.middleware import AuditConfig, AuditMiddleware
+        from bh_fastapi_audit.sinks.base import AuditSink
+
+        class DummySink(AuditSink):
+            def emit(self, event: dict[str, Any]) -> None:
+                pass
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_stale_state(tmpdir)
+            config = AuditConfig(
+                service_name="test",
+                telemetry_enabled=False,
+                telemetry_deployment_id_path=tmpdir,
+            )
+            mw = AuditMiddleware(app=None, sink=DummySink(), config=config)
+            assert mw._telemetry is None
+
+
+# ======================================================================
+# Log level configuration
+# ======================================================================
+
+
+class TestLogLevel:
+    def test_failure_logs_at_configured_level(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir, log_level=logging.ERROR)
+            emitter._counters.increment(_make_event())
+            with (
+                patch(
+                    "bh_fastapi_audit._telemetry.urlopen",
+                    side_effect=OSError("fail"),
+                ),
+                patch("bh_fastapi_audit._telemetry._log") as mock_log,
+            ):
+                emitter.flush()
+            mock_log.log.assert_called()
+            assert mock_log.log.call_args_list[0][0][0] == logging.ERROR
+
+    def test_failure_log_does_not_include_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir, log_level=logging.WARNING)
+            emitter._counters.increment(_make_event())
+            with (
+                patch(
+                    "bh_fastapi_audit._telemetry.urlopen",
+                    side_effect=OSError("fail"),
+                ),
+                patch("bh_fastapi_audit._telemetry._log") as mock_log,
+            ):
+                emitter.flush()
+            _, kwargs = mock_log.log.call_args
+            assert kwargs.get("exc_info") is not True
+
+
+# ======================================================================
+# HTTP timeout configuration
+# ======================================================================
+
+
+class TestHttpTimeout:
+    def test_http_timeout_passed_to_urlopen(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            emitter = _make_emitter(tmpdir, http_timeout_s=2.5)
+            emitter._counters.increment(_make_event())
+            with _mock_urlopen_ok() as mock_urlopen:
+                emitter.flush()
+                args, kwargs = mock_urlopen.call_args
+                timeout = kwargs.get("timeout", args[1] if len(args) > 1 else None)
+                assert timeout == 2.5
+
+
+# ======================================================================
+# Shutdown integration
+# ======================================================================
+
+
+class TestShutdownIntegration:
+    def test_shutdown_calls_telemetry_flush_blocking(self) -> None:
+        import asyncio
+
+        from bh_fastapi_audit.middleware import AuditConfig, AuditMiddleware
+        from bh_fastapi_audit.sinks.base import AuditSink
+
+        class DummySink(AuditSink):
+            def emit(self, event: dict[str, Any]) -> None:
+                pass
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = AuditConfig(
+                service_name="test",
+                telemetry_enabled=True,
+                telemetry_deployment_id_path=tmpdir,
+                emit_mode="sync",
+            )
+            with _mock_urlopen_ok():
+                mw = AuditMiddleware(app=None, sink=DummySink(), config=config)
+
+            assert mw._telemetry is not None
+            with patch.object(mw._telemetry, "flush") as mock_flush:
+                asyncio.get_event_loop().run_until_complete(mw.shutdown())
+                mock_flush.assert_called_once()


### PR DESCRIPTION

### Changed

- **Lambda-safe telemetry** — telemetry system rewritten for ephemeral/serverless
  environments.  Dual-trigger flush (interval **or** event threshold, whichever comes
  first, default 300s / 500 events).  Mid-request flushes use a fire-and-forget daemon
  thread (zero added latency).  Disk-backed counter persistence survives cold starts.
  `AuditMiddleware.shutdown()` now flushes telemetry (blocking, bounded by
  `telemetry_http_timeout_s`).  Failure logging raised from `DEBUG` to configurable
  `telemetry_log_level` (default `WARNING`).
- Five new `AuditConfig` fields: `telemetry_flush_interval_seconds`,
  `telemetry_event_flush_threshold`, `telemetry_log_level`,
  `telemetry_http_timeout_s`, `telemetry_flush_stale_on_init`.
- Updated `docs/telemetry.md` with Lambda configuration section and cold-start
  latency guidance.

### Fixed

- **Telemetry payload format** — telemetry report now uses `"schema": "bh-telemetry-v1"`
  and nested `"period": {"start": ..., "end": ...}` to match the receiver Lambda API.
  The v1.0.0 format was silently rejected with HTTP 400; telemetry was never actually
  delivered.