### PR TITLE
vendor schema 1.1.2 + enum parity test (1.1.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,11 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.claude/
+.cursor/
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-12
+
+### Changed
+
+- Vendored v1.1 schema updated to use `$defs` for `ActionType`, `OutcomeStatus`,
+  and `DataClassification` (upstream bh-audit-schema#5, no value changes).
+
+### Added
+
+- `tests/test_enum_parity.py` -- guards Python `Literal` types against drift
+  from vendored schema `$defs` enum arrays.
+
 ## [1.1.0] - 2026-04-13
 
 ### Changed
@@ -381,6 +393,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apache 2.0 license
 - Vendored bh-audit-schema v1.0 JSON schema
 
+[1.1.1]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/bh-healthcare/bh-fastapi-audit/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The goal of this library is to make consistent, structured audit trails easy to 
 
 This project is an implementation layer that turns the bh-audit-schema standard into working FastAPI middleware.
 
-**Current version: v1.1.0** — Lambda-safe telemetry, Verifier CLI, chain hashing, DynamoDB sink, runtime validation, DENIED outcome with denial callbacks, schema negotiation.
+**Current version: v1.1.1** — Lambda-safe telemetry, Verifier CLI, chain hashing, DynamoDB sink, runtime validation, DENIED outcome with denial callbacks, schema negotiation. Vendored schema uses `$defs` for enum types.
 
 ### v1.0 (current)
 - **Verifier CLI** — `bh-audit verify` for chain integrity verification (file or DynamoDB source, human or JSON output)
@@ -52,7 +52,10 @@ This project is an implementation layer that turns the bh-audit-schema standard 
   - `SQLAlchemySink` — relational database storage (Postgres, SQLite, etc., via SQLAlchemy Core)
 - Redaction utilities for error message sanitization
 
-The bh-audit-schema v1.0 and v1.1 JSON schemas are vendored into this package to enable offline validation.
+The bh-audit-schema v1.0 and v1.1 JSON schemas are vendored into this package to
+enable offline validation. The vendored v1.1 schema currently tracks **bh-audit-schema
+v1.1.2**, which defines `ActionType`, `OutcomeStatus`, and `DataClassification` as
+named `$defs` referenced via `$ref` (accepted values unchanged).
 
 ## Quickstart
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bh-fastapi-audit"
-version = "1.1.0"
+version = "1.1.1"
 description = "FastAPI ASGI middleware for emitting PHI-safe audit events for behavioral healthcare systems"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [
-    { name = "BH Healthcare", email = "oss@bh-healthcare.github.io" }
+    { name = "BH Healthcare", email = "oss@bh-healthcare.org" }
 ]
 keywords = [
     "fastapi",

--- a/src/bh_fastapi_audit/__init__.py
+++ b/src/bh_fastapi_audit/__init__.py
@@ -5,7 +5,7 @@ This package provides pure ASGI middleware for emitting structured audit events
 conforming to the bh-audit-schema v1.1 standard for behavioral healthcare systems.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from bh_fastapi_audit._chain import canonical_serialize, compute_chain_hash
 from bh_fastapi_audit._chain_state import ChainState

--- a/src/bh_fastapi_audit/schema/audit_event.schema.json
+++ b/src/bh_fastapi_audit/schema/audit_event.schema.json
@@ -4,6 +4,23 @@
   "title": "BH Audit Event",
   "type": "object",
   "additionalProperties": false,
+  "$defs": {
+    "ActionType": {
+      "type": "string",
+      "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"],
+      "description": "Canonical action taxonomy for BH audit events."
+    },
+    "OutcomeStatus": {
+      "type": "string",
+      "enum": ["SUCCESS", "FAILURE", "DENIED"],
+      "description": "Terminal outcome classification for an audited action."
+    },
+    "DataClassification": {
+      "type": "string",
+      "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+      "description": "Regulatory classification of the data touched by the action."
+    }
+  },
   "required": [
     "schema_version",
     "event_id",
@@ -88,10 +105,7 @@
       "additionalProperties": false,
       "required": ["type"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"]
-        },
+        "type": { "$ref": "#/$defs/ActionType" },
         "name": {
           "type": "string",
           "maxLength": 128,
@@ -102,8 +116,7 @@
           "description": "True if the action touches regulated PHI (behavioral health context)."
         },
         "data_classification": {
-          "type": "string",
-          "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+          "$ref": "#/$defs/DataClassification",
           "default": "UNKNOWN"
         }
       }
@@ -147,7 +160,7 @@
       "additionalProperties": false,
       "required": ["status"],
       "properties": {
-        "status": { "type": "string", "enum": ["SUCCESS", "FAILURE", "DENIED"] },
+        "status": { "$ref": "#/$defs/OutcomeStatus" },
         "error_type": { "type": "string", "minLength": 1, "maxLength": 128 },
         "error_message": {
           "type": "string",

--- a/src/bh_fastapi_audit/schema/versions/1.1/audit_event.schema.json
+++ b/src/bh_fastapi_audit/schema/versions/1.1/audit_event.schema.json
@@ -4,6 +4,23 @@
   "title": "BH Audit Event",
   "type": "object",
   "additionalProperties": false,
+  "$defs": {
+    "ActionType": {
+      "type": "string",
+      "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"],
+      "description": "Canonical action taxonomy for BH audit events."
+    },
+    "OutcomeStatus": {
+      "type": "string",
+      "enum": ["SUCCESS", "FAILURE", "DENIED"],
+      "description": "Terminal outcome classification for an audited action."
+    },
+    "DataClassification": {
+      "type": "string",
+      "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+      "description": "Regulatory classification of the data touched by the action."
+    }
+  },
   "required": [
     "schema_version",
     "event_id",
@@ -88,10 +105,7 @@
       "additionalProperties": false,
       "required": ["type"],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["READ", "CREATE", "UPDATE", "DELETE", "EXPORT", "LOGIN", "LOGOUT", "PRINT", "OTHER"]
-        },
+        "type": { "$ref": "#/$defs/ActionType" },
         "name": {
           "type": "string",
           "maxLength": 128,
@@ -102,8 +116,7 @@
           "description": "True if the action touches regulated PHI (behavioral health context)."
         },
         "data_classification": {
-          "type": "string",
-          "enum": ["PHI", "PII", "NONE", "UNKNOWN"],
+          "$ref": "#/$defs/DataClassification",
           "default": "UNKNOWN"
         }
       }
@@ -147,7 +160,7 @@
       "additionalProperties": false,
       "required": ["status"],
       "properties": {
-        "status": { "type": "string", "enum": ["SUCCESS", "FAILURE", "DENIED"] },
+        "status": { "$ref": "#/$defs/OutcomeStatus" },
         "error_type": { "type": "string", "minLength": 1, "maxLength": 128 },
         "error_message": {
           "type": "string",

--- a/tests/test_enum_parity.py
+++ b/tests/test_enum_parity.py
@@ -1,0 +1,22 @@
+"""Guard against drift between Python Literal types and vendored schema $defs."""
+
+from typing import get_args
+
+from bh_fastapi_audit._types import ActionType, DataClassification, OutcomeStatus
+from bh_fastapi_audit.schema import load_schema
+
+
+class TestEnumParity:
+    def test_action_type_matches_schema(self):
+        schema = load_schema("1.1")
+        assert set(get_args(ActionType)) == set(schema["$defs"]["ActionType"]["enum"])
+
+    def test_outcome_status_matches_schema(self):
+        schema = load_schema("1.1")
+        assert set(get_args(OutcomeStatus)) == set(schema["$defs"]["OutcomeStatus"]["enum"])
+
+    def test_data_classification_matches_schema(self):
+        schema = load_schema("1.1")
+        assert set(get_args(DataClassification)) == set(
+            schema["$defs"]["DataClassification"]["enum"]
+        )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -129,7 +129,7 @@ def test_version_exposed():
     from bh_fastapi_audit import __version__
 
     assert isinstance(__version__, str)
-    assert __version__ == "1.1.0"
+    assert __version__ == "1.1.1"
 
 
 def test_all_exports_defined():


### PR DESCRIPTION
## [1.1.1] - 2026-05-12

### Changed

- Vendored v1.1 schema updated to use `$defs` for `ActionType`, `OutcomeStatus`,
  and `DataClassification` (upstream bh-audit-schema#5, no value changes).

### Added

- `tests/test_enum_parity.py` -- guards Python `Literal` types against drift
  from vendored schema `$defs` enum arrays.